### PR TITLE
Make Git case sensitive on OSX

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -13,6 +13,7 @@
   whitespace = nowarn
 [color]
   ui = auto
+  ignorecase = false
 [branch "master"]
   remote = origin
   merge = refs/heads/master


### PR DESCRIPTION
Git won't recognize changes in filename case by default in OSX, since the file system isn't case sensitive. Setting ignoreCase to false forces Git to be case-sensitive in some cases. 

I just updated my dotfiles today. One of my coworkers ran into this issue last week. This doesn't fix the problem, there are still times where case will be ignored when it shouldn't be, but this will at least cause Git to recognize case in new files.