### PR TITLE
Use three way diff in git merges to make conflict resolution easier

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -45,6 +45,7 @@
 [include]
   path = ~/.gitconfig.local
 [merge]
+  conflictstyle = diff3
   ff = only
 [pull]
   rebase = preserve


### PR DESCRIPTION
The diff3 setting causes git generate three way diffs when conflicts occur. Normally git diffs just show HEAD and conflicting commit. Three way diffs show HEAD, the conflicting commit, and the parent commit. This is very useful when rebasing.