### PR TITLE
Add 'recent' alias to git so recently updated branches can be easily viewed

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -4,6 +4,7 @@
   ap = add --patch
   b = branch
   ba = branch --all
+  recent = for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD) %(color:yellow)%(refname:short)%(color:reset) - %(color:red)%(objectname:short)%(color:reset) - %(contents:subject) - %(authorname) (%(color:green)%(committerdate:relative)%(color:reset))'
   ca = commit --amend
   car = commit --amend --no-edit
   co = checkout


### PR DESCRIPTION
I've recently been working on a project with a lot of branches. This command has been helpful. It's list branches sorted by most recently updated (most recently updated is at the bottom of the list). It also shows the most recent commit message and commiter. You could remove them if you want to, lines do tend to get a little long with the commit messages in them.