### PR TITLE
Prompt Update

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -2,57 +2,84 @@
   a = add
   aa = add --all
   ap = add --patch
+
   b = branch
   ba = branch --all
-  recent = for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD) %(color:yellow)%(refname:short)%(color:reset) - %(color:red)%(objectname:short)%(color:reset) - %(contents:subject) - %(authorname) (%(color:green)%(committerdate:relative)%(color:reset))'
+
   ca = commit --amend
-  car = commit --amend --no-edit
   co = checkout
   ci = commit -v
+
   dc = diff --word-diff --cached --color-words
   df = diff --word-diff --color-words
   dfs = diff --staged
+
   lg = log --stat --color
+  lgg = log --graph --color
+  lga = log --graph --decorate --all
+  lgm = log --graph --max-count=10
+  lgp = log --stat --color --patch
+  lo = log --oneline --decorate --color
+  lor = log --oneline --decorate --color --graph
+  lol = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+  loa = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all
+
   mup = !git checkout master && git pull && git checkout -
+
   pl = pull
   pum = push -u origin master
   ps = push
-  sl = log --graph --pretty=format:'%C(yellow)%h%Creset - %C(white)%d%Creset %s %Cblue(%an, %ar)%Creset'
-  sla = log --oneline --decorate --all --graph
-  st = status --short --branch
-  sta = status
+
+  sta = status --short --branch
+  st = status
+
+  recent = for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD) %(color:yellow)%(refname:short)%(color:reset) - %(color:red)%(objectname:short)%(color:reset) - %(contents:subject) - %(authorname) (%(color:green)%(committerdate:relative)%(color:reset))'
+
   unstage = reset
   uncommit = reset --soft HEAD^
+
 [apply]
   whitespace = nowarn
+
 [color]
   ui = auto
   ignorecase = false
+
 [commit]
   template = ~/.gitmessage
+
 [core]
   autocrlf = input
   safecrlf = true
   editor = vim
   excludesfile = ~/.gitignore_global
+
 [fetch]
   prune = true
+
 [gitsh]
   defaultCommand = status --short --branch
+
 [gitsh "color"]
   default = blue
   untracked = yellow
   modified = red
+
 [include]
   path = ~/.gitconfig.local
+
 [merge]
   conflictstyle = diff3
   ff = only
+
 [pull]
   rebase = preserve
+
 [push]
   default = upstream
+
 [url "https://github.com/"]
   insteadOf = git@github.com:
+
 [url "https://"]
   insteadOf = git://

--- a/gitconfig
+++ b/gitconfig
@@ -5,14 +5,18 @@
 
   b = branch
   ba = branch --all
+  br = branch --remote
 
   ca = commit --amend
-  co = checkout
   ci = commit -v
+  co = checkout
+  com = checkout master
 
   dc = diff --word-diff --cached --color-words
   df = diff --word-diff --color-words
   dfs = diff --staged
+
+  f = fetch
 
   lg = log --stat --color
   lgg = log --graph --color
@@ -34,9 +38,12 @@
   st = status
 
   recent = for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD) %(color:yellow)%(refname:short)%(color:reset) - %(color:red)%(objectname:short)%(color:reset) - %(contents:subject) - %(authorname) (%(color:green)%(committerdate:relative)%(color:reset))'
+  rv = remote -v
 
   unstage = reset
   uncommit = reset --soft HEAD^
+
+  wch = whatchanged -p --abbrev-commit --pretty=medium
 
 [apply]
   whitespace = nowarn

--- a/tmux.conf
+++ b/tmux.conf
@@ -13,7 +13,7 @@ unbind C-b
 
 # Make splitting windows easier
 bind-key v split-window -h
-bind-key s split-window -v -p 27
+bind-key s split-window -v -p 22
 
 # Moving between panes
 bind h select-pane -L

--- a/zsh/aliases
+++ b/zsh/aliases
@@ -105,6 +105,10 @@ alias bsl='brew services list'
 alias bsr='brew services restart'
 alias bs0='brew services stop'
 alias bs1='brew services start'
+alias brews='brew list -1'
+alias bubo='brew update && brew outdated'
+alias bubc='brew upgrade && brew cleanup'
+alias bubu='bubo && bubc'
 
 # Mac App Store (https://github.com/argon/mas)
 alias masi='mas install'

--- a/zsh/oh-my-zsh
+++ b/zsh/oh-my-zsh
@@ -3,6 +3,6 @@ DISABLE_UPDATE_PROMPT=true
 DISABLE_AUTO_UPDATE=true
 COMPLETION_WAITING_DOTS="true"
 
-plugins=(git brew rails osx)
+plugins=()
 
 source $ZSH/oh-my-zsh.sh

--- a/zsh/prompt
+++ b/zsh/prompt
@@ -44,7 +44,8 @@ ZSH_THEME_GIT_PROMPT_SHA_AFTER="%{$fg[reset_color]%}"
 local user='%{$fg[green]%}%m:%{$reset_color%}'
 local ssh_user='%{$fg[magenta]%}%n@%m:%{$reset_color%}'
 local pwd='%{$fg[blue]%}%~%{$reset_color%}'
-local git='$(git_prompt_short_sha)%{$fg[white]%}$(my_git_branch)%{$reset_color%}'
+local git='%{$fg[white]%}$(my_git_branch)%{$reset_color%}$(git_prompt_short_sha)%{$reset_color%}'
+local datetime='[%D{%Y-%m-%d %H:%M:%S}]'
 
 _rubyprompt() {
   if [ $COLUMNS -gt 80 ]; then
@@ -52,13 +53,8 @@ _rubyprompt() {
   fi
 }
 
-if [[ -n $SSH_CONNECTION ]]; then
-  PROMPT="${ssh_user}${pwd}${git}
-%(?..%{$fg[red]%})%B%%%b "
-else
-  PROMPT="${pwd}${git}
-%(?.%{$fg[green]%}.%{$fg[red]%})%B%%%b "
-fi
+PROMPT="${datetime} ${pwd}${git}
+%(?..%{$fg[red]%})%B$%b "
 
 setopt transient_rprompt # only show the rprompt on the current prompt
 

--- a/zsh/prompt
+++ b/zsh/prompt
@@ -1,4 +1,3 @@
-# Ruby version in prompt
 function get_ruby_version() {
   if command -v ruby >/dev/null; then
     ruby -v | awk '{print $1 " " $2}'
@@ -7,53 +6,49 @@ function get_ruby_version() {
   fi
 }
 
-# Echo commits ahead only if remote exists.
-function my_remote_status() {
-  if [[ -n "$(command git show-ref origin/$(git_current_branch) 2> /dev/null)" ]]; then
-    echo "$(git_commits_ahead)"
-  fi
-}
-
-# Get the name of the branch we are on
-# Adapted from git_prompt_info(), .oh-my-zsh/lib/git.zsh
-function my_git_branch() {
-  if [[ "$(command git config --get oh-my-zsh.hide-status 2>/dev/null)" != "1" ]]; then
-    ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
-    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
-    echo " $(my_remote_status)$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$(git_prompt_status)$ZSH_THEME_GIT_PROMPT_SUFFIX"
-  fi
-}
-
-ZSH_THEME_GIT_COMMITS_AHEAD_PREFIX="%{$fg[magenta]%}↑"
-ZSH_THEME_GIT_COMMITS_AHEAD_SUFFIX="%{$fg[white]%} "
-
-ZSH_THEME_GIT_PROMPT_PREFIX="["
-ZSH_THEME_GIT_PROMPT_SUFFIX="]"
-ZSH_THEME_GIT_PROMPT_DIRTY=""
-ZSH_THEME_GIT_PROMPT_CLEAN=""
-ZSH_THEME_GIT_PROMPT_AHEAD=""
-ZSH_THEME_GIT_PROMPT_ADDED="%{$fg[green]%}+%{$fg[white]%}"
-ZSH_THEME_GIT_PROMPT_MODIFIED="%{$fg[red]%}*%{$fg[white]%}"
-ZSH_THEME_GIT_PROMPT_DELETED="%{$fg[red]%}-%{$fg[white]%}"
-ZSH_THEME_GIT_PROMPT_RENAMED="%{$fg[magenta]%}>%{$fg[white]%}"
-ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[yellow]%}═%{$fg[white]%}"
-ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[cyan]%}#%{$fg[white]%}"
-ZSH_THEME_GIT_PROMPT_SHA_BEFORE=" %{$fg[green]%}"
-ZSH_THEME_GIT_PROMPT_SHA_AFTER="%{$fg[reset_color]%}"
-
-local user='%{$fg[green]%}%m:%{$reset_color%}'
-local ssh_user='%{$fg[magenta]%}%n@%m:%{$reset_color%}'
-local pwd='%{$fg[blue]%}%~%{$reset_color%}'
-local git='%{$fg[white]%}$(my_git_branch)%{$reset_color%}$(git_prompt_short_sha)%{$reset_color%}'
-local datetime='[%D{%Y-%m-%d %H:%M:%S}]'
-
 _rubyprompt() {
   if [ $COLUMNS -gt 80 ]; then
     echo "$(get_ruby_version)"
   fi
 }
 
-PROMPT="${datetime} ${pwd}${git}
+function my_remote_status() {
+  echo "$(git_commits_ahead)$(git_commits_behind)"
+}
+
+# Adapted from git_prompt_info(): oh-my-zsh/lib/git.zsh
+function my_git_prompt() {
+  local ref
+  if [[ "$(command git config --get oh-my-zsh.hide-status 2>/dev/null)" != "1" ]]; then
+    ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
+    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return 0
+    echo "$ZSH_THEME_GIT_PROMPT_PREFIX$(git_current_branch)$(git_prompt_status)$ZSH_THEME_GIT_PROMPT_SUFFIX $(my_remote_status)"
+  fi
+}
+
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[white]%}["
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$fg[white]%}]%{$reset_color%}"
+
+ZSH_THEME_GIT_COMMITS_AHEAD_PREFIX="%{$fg[magenta]%}↑"
+ZSH_THEME_GIT_COMMITS_AHEAD_SUFFIX=" %{$reset_color%}"
+ZSH_THEME_GIT_COMMITS_BEHIND_PREFIX="%{$fg[cyan]%}↓"
+ZSH_THEME_GIT_COMMITS_BEHIND_SUFFIX=" %{$reset_color%}"
+
+ZSH_THEME_GIT_PROMPT_ADDED="%{$fg[green]%}+"
+ZSH_THEME_GIT_PROMPT_MODIFIED="%{$fg[red]%}*"
+ZSH_THEME_GIT_PROMPT_DELETED="%{$fg[red]%}-"
+ZSH_THEME_GIT_PROMPT_RENAMED="%{$fg[magenta]%}>"
+ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg[yellow]%}ǁ"
+ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg[cyan]%}●"
+ZSH_THEME_GIT_PROMPT_STASHED="%{$fg[yellow]%}⚑"
+ZSH_THEME_GIT_PROMPT_SHA_BEFORE="%{$fg[green]%}"
+ZSH_THEME_GIT_PROMPT_SHA_AFTER="%{$reset_color%}"
+
+local datetime='[%{$fg[yellow]%}%D{%Y-%m-%d %H:%M:%S}%{$reset_color%}]'
+local pwd='%{$fg[blue]%}%~%{$reset_color%}'
+local git='$(my_git_prompt)$(git_prompt_short_sha)'
+
+PROMPT="${datetime} ${pwd} ${git}
 %(?..%{$fg[red]%})%B$%b "
 
 setopt transient_rprompt # only show the rprompt on the current prompt


### PR DESCRIPTION
This PR primarily enhances my prompt, but also adds a few misc improvements.

* Add datetime stamp
* Show commits ahead AND behind remote branch
* Update git prompt symbols
* Add symbol for stashes
* Refactor and cleanup code
* Reduce vertical tmux split to 22
* Add several homebrew aliases
* Remove all oh-my-zsh plugins. I've integrated what I need directly into my dotfiles.
* Update git aliases. I most use git via [gitsh](https://github.com/thoughtbot/gitsh) so I'm now keeping all my git aliases in my gitconfig.