### PR TITLE
Touch ~/.zshrc.profiler to profile zshrc startup time

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ I'm currently trying out Neovim, and so far things are working nicely. For now I
 * https://neovim.io/doc/user/nvim.html#nvim-from-vim
 * https://neovim.io/doc/user/vim_diff.html#vim-differences
 
+## Identifying Sources of Slow Startup Times
+
+The .zshrc script can be profiled by touching the file `~/.zshrc.profiler` and starting a new login shell. To see the top 20 
+lines that are taking the most time use the `zshrc_profiler_view`. `zshrc_profiler` parameters are number of lines to show (20)
+and path to profiler log file ($TMPDIR/zshrc_profiler.${PID}log).
+
 ## Some of my favorite dotfile repos
 
 * Pro Vim (https://github.com/Integralist/ProVim)

--- a/zsh/profiler
+++ b/zsh/profiler
@@ -1,0 +1,34 @@
+# credit to  https://esham.io/2018/02/zsh-profiling
+
+# call no params : view top 20 lines for this process's log file
+#  param 1 - number of lines to use
+#  param 2 - path to profile log
+zshrc_profiler_view() {
+
+  typeset -a lines
+  typeset -i prev_time=0
+  typeset prev_command
+
+  while read line; do
+      if [[ $line =~ '^.*\+([0-9]{10})\.([0-9]{6})[0-9]* (.+)' ]]; then
+          integer this_time=$match[1]$match[2]
+
+          if [[ $prev_time -gt 0 ]]; then
+              time_difference=$(( $this_time - $prev_time ))
+              lines+="$time_difference $prev_command"
+          fi
+
+          prev_time=$this_time
+
+          local this_command=$match[3]
+          if [[ ${#this_command} -le 132 ]]; then
+              prev_command=$this_command
+          else
+              prev_command="${this_command:0:77}..."
+          fi
+      fi
+  done < ${2:-${TMPDIR}/zshrc_profiler.$$.log}
+
+  print -l ${(@On)lines} | head -n ${1:-20}
+
+}

--- a/zsh/profiler.start
+++ b/zsh/profiler.start
@@ -1,0 +1,13 @@
+# Credit goes to https://esham.io/2018/02/zsh-profiling
+if [ -f $HOME/.zshrc.profiler ]; then
+
+   source $HOME/dotfiles/zsh/profiler
+   zmodload zsh/datetime
+   setopt PROMPT_SUBST
+   PS4='+$EPOCHREALTIME %N:%i> '
+
+   zshrc_profiler_logfile=$TMPDIR/zshrc_profiler.$$.log
+   echo "Logging script execution to $zshrc_profiler_logfile"
+   exec 3>&2 2>$zshrc_profiler_logfile
+   setopt XTRACE
+fi

--- a/zsh/profiler.stop
+++ b/zsh/profiler.stop
@@ -1,0 +1,6 @@
+if [ -f $HOME/.zshrc.profiler ]; then
+  unsetopt XTRACE
+  echo ".zshrc profiling complete."
+  exec 2>&3 3>&-
+  echo "View top time consumers with: zshrc_profiler_view"
+fi

--- a/zshrc
+++ b/zshrc
@@ -1,4 +1,5 @@
 # ~/.zshrc
+. $HOME/dotfiles/zsh/profiler.start
 
 export PATH=$HOME/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin
 export EDITOR="nvim"
@@ -58,3 +59,5 @@ export KEYTIMEOUT=1
 
 # Include local settings
 [[ -f ~/.zshrc.local ]] && . ~/.zshrc.local
+
+. $HOME/dotfiles/zsh/profiler.stop


### PR DESCRIPTION
Profile zshrc execution time. I found one culprit that took 1.5s (i.e. forever!). touch the file to activate the profiler.