### PR TITLE
Iterm2 schemes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "iterm2/iTerm2-Color-Schemes"]
+	path = iterm2/iTerm2-Color-Schemes
+	url = https://github.com/mbadolato/iTerm2-Color-Schemes

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Thanks to a [great blog post][blog-post] by Trevor Brown, I learned that you can
 1. Press "Browse" and point it to `~/dotfiles/iterm2/com.googlecode.iterm2.plist`.
 1. Restart iTerm2.
 
+Additionally iTerm2 provides a great collection of color schemes to give your terminal that personal touch. I've included in dotfiles so you only need to head over to iTerm2 > Preferences > Profiles > Colors and select "Import" from the Color Presets control. Color scheme files are found in  `~/dotfiles/iTerm2/iTerm2-Color-Schemes/schemes/` and can be viewed [online](https://github.com/mbadolato/iTerm2-Color-Schemes).
+
 ## Setting up Terminal.app
 
 Getting set up after a fresh install is simple.


### PR DESCRIPTION
You may not want the submodule link - the (used to be) can be confusing. If you do , here's a helpful one that gives users easy access to the color schemes for iTerm2