### PR TITLE
Switch to vim-test

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -329,7 +329,6 @@ Plug 'tpope/vim-repeat'                 " Enable repeating supported plugin maps
 Plug 'tpope/vim-sensible'               " Defaults everyone can agree on                        | https://github.com/tpope/vim-sensible
 
 " Testing & Tmux
-" Plug 'thoughtbot/vim-rspec'             " Run Rspec specs from Vim                              | https://github.com/thoughtbot/vim-rspec
 Plug 'janko/vim-test'                   " Run your tests at the speed of thought                | https://github.com/janko/vim-test
 Plug 'christoomey/vim-tmux-runner'      " Command runner for sending commands from vim to tmux. | https://github.com/christoomey/vim-tmux-runner
 
@@ -363,13 +362,6 @@ nnoremap <silent> <F4> :BufExplorer<CR>
 
 " Obsession
 map <leader>ob :Obsession<CR>
-
-" vim-rspec
-" map <leader>f :call RunCurrentSpecFile()<CR>
-" map <leader>n :call RunNearestSpec()<CR>
-" map <leader>l :call RunLastSpec()<CR>
-" map <leader>a :call RunAllSpecs()<CR>
-" let g:rspec_command = 'VtrSendCommandToRunner! clear; rspec {spec}'
 
 " vim-test
 nmap <silent> t<C-n> :TestNearest<CR>

--- a/vimrc
+++ b/vimrc
@@ -329,7 +329,8 @@ Plug 'tpope/vim-repeat'                 " Enable repeating supported plugin maps
 Plug 'tpope/vim-sensible'               " Defaults everyone can agree on                        | https://github.com/tpope/vim-sensible
 
 " Testing & Tmux
-Plug 'thoughtbot/vim-rspec'             " Run Rspec specs from Vim                              | https://github.com/thoughtbot/vim-rspec
+" Plug 'thoughtbot/vim-rspec'             " Run Rspec specs from Vim                              | https://github.com/thoughtbot/vim-rspec
+Plug 'janko/vim-test'                   " Run your tests at the speed of thought                | https://github.com/janko/vim-test
 Plug 'christoomey/vim-tmux-runner'      " Command runner for sending commands from vim to tmux. | https://github.com/christoomey/vim-tmux-runner
 
 call plug#end()
@@ -364,11 +365,19 @@ nnoremap <silent> <F4> :BufExplorer<CR>
 map <leader>ob :Obsession<CR>
 
 " vim-rspec
-map <leader>f :call RunCurrentSpecFile()<CR>
-map <leader>n :call RunNearestSpec()<CR>
-map <leader>l :call RunLastSpec()<CR>
-map <leader>a :call RunAllSpecs()<CR>
-let g:rspec_command = 'VtrSendCommandToRunner! clear; rspec {spec}'
+" map <leader>f :call RunCurrentSpecFile()<CR>
+" map <leader>n :call RunNearestSpec()<CR>
+" map <leader>l :call RunLastSpec()<CR>
+" map <leader>a :call RunAllSpecs()<CR>
+" let g:rspec_command = 'VtrSendCommandToRunner! clear; rspec {spec}'
+
+" vim-test
+nmap <silent> t<C-n> :TestNearest<CR>
+nmap <silent> t<C-f> :TestFile<CR>
+nmap <silent> t<C-s> :TestSuite<CR>
+nmap <silent> t<C-l> :TestLast<CR>
+nmap <silent> t<C-g> :TestVisit<CR>
+let test#strategy = 'vtr'
 
 " vim-tmux-runner
 let g:VtrPercentage = 25


### PR DESCRIPTION
`vim-test` appears to offer all the same features (and maybe more?) as `vim-rspec`, but also works with languages and test runners beyond Ruby/Rspec. This is needful now that I am writing JS tests. 

Nice that it also interfaces with `vim-tmux-runner`! 😁

https://github.com/janko/vim-test