### PR TITLE
Tmux Custom Overrides

### DIFF
--- a/machines/family-imac/tmux.conf.custom
+++ b/machines/family-imac/tmux.conf.custom
@@ -1,6 +1,4 @@
-# Enable UTF-8 support in status bar
-set -g status on
-
+# Status bar background color.
 # set -g status-style bg=#2c3b41 # For Material colorscheme
 # set -g status-style bg=#112630 # For Night Owl colorscheme
 # set -g status-style bg=#3B4252 # For Nord colorscheme
@@ -9,13 +7,5 @@ set -g status-style bg=#313640 # For One Half Dark colorscheme
 # set -g status-style bg=#323232 # For Tender Dark colorscheme
 # set -g status-style bg=black # For Solarized colorscheme
 # set -g status-style bg=#2c323c # For Vim One colorscheme
-
-# Status bar settings
-set -g status-left-length 60
-set -g status-left "#[fg=green][#S] #[fg=red]w#I #[fg=blue]p#P"
-set -g status-right-length 60
-set -g status-right " #[fg=white]%a, %b %d | %H:%M "
-set -g status-interval 15 # default is 15
-set -g status-justify centre
 
 # vim: set filetype=tmux:

--- a/machines/joshuas-imac/tmux.conf.custom
+++ b/machines/joshuas-imac/tmux.conf.custom
@@ -1,21 +1,20 @@
-# Enable UTF-8 support in status bar
-set -g status on
+# pane colors
+set -g pane-border-style bg=default,fg=$BLACK
+set -g pane-active-border-style bg=default,fg=$BRIGHT_BLUE
 
+# set the color of the window list
+setw -g window-status-style fg=$BLACK,bg=$BRIGHT_BLUE
+
+# Status bar settings
+set -g status-left "#[fg=$GREEN][#S] #[fg=$RED]w#I #[fg=$BRIGHT_BLUE]p#P"
+
+# Status bar background color.
 # set -g status-style bg=#2c3b41 # For Material colorscheme
 # set -g status-style bg=#112630 # For Night Owl colorscheme
 # set -g status-style bg=#3B4252 # For Nord colorscheme
 # set -g status-style bg=#343d46 # For Oceanic Next colorscheme
 # set -g status-style bg=#313640 # For One Half Dark colorscheme
 set -g status-style bg=#323232 # For Tender Dark colorscheme
-# set -g status-style bg=black # For Solarized colorscheme
 # set -g status-style bg=#2c323c # For Vim One colorscheme
-
-# Status bar settings
-set -g status-left-length 60
-set -g status-left "#[fg=green][#S] #[fg=red]w#I #[fg=blue]p#P"
-set -g status-right-length 60
-set -g status-right " #[fg=white]%a, %b %d | %H:%M "
-set -g status-interval 15 # default is 15
-set -g status-justify centre
 
 # vim: set filetype=tmux:

--- a/machines/joshuas-mbp15/tmux.conf.custom
+++ b/machines/joshuas-mbp15/tmux.conf.custom
@@ -1,6 +1,4 @@
-# Enable UTF-8 support in status bar
-set -g status on
-
+# Status bar background color.
 # set -g status-style bg=#2c3b41 # For Material colorscheme
 # set -g status-style bg=#112630 # For Night Owl colorscheme
 # set -g status-style bg=#3B4252 # For Nord colorscheme
@@ -9,13 +7,5 @@ set -g status-style bg=#313640 # For One Half Dark colorscheme
 # set -g status-style bg=#323232 # For Tender Dark colorscheme
 # set -g status-style bg=black # For Solarized colorscheme
 # set -g status-style bg=#2c323c # For Vim One colorscheme
-
-# Status bar settings
-set -g status-left-length 60
-set -g status-left "#[fg=green][#S] #[fg=red]w#I #[fg=blue]p#P"
-set -g status-right-length 60
-set -g status-right " #[fg=white]%a, %b %d | %H:%M "
-set -g status-interval 15 # default is 15
-set -g status-justify centre
 
 # vim: set filetype=tmux:

--- a/machines/joshuas-mbp15/tmux.conf.custom
+++ b/machines/joshuas-mbp15/tmux.conf.custom
@@ -1,3 +1,6 @@
+# pane colors
+set -g pane-border-style bg=default,fg="#5c6370"
+
 # Status bar background color.
 # set -g status-style bg=#2c3b41 # For Material colorscheme
 # set -g status-style bg=#112630 # For Night Owl colorscheme

--- a/machines/kelsies-mbp13/tmux.conf.custom
+++ b/machines/kelsies-mbp13/tmux.conf.custom
@@ -1,6 +1,4 @@
-# Enable UTF-8 support in status bar
-set -g status on
-
+# Status bar background color.
 # set -g status-style bg=#2c3b41 # For Material colorscheme
 # set -g status-style bg=#112630 # For Night Owl colorscheme
 set -g status-style bg=#3B4252 # For Nord colorscheme
@@ -8,13 +6,5 @@ set -g status-style bg=#3B4252 # For Nord colorscheme
 # set -g status-style bg=#323232 # For Tender Dark colorscheme
 # set -g status-style bg=black # For Solarized colorscheme
 # set -g status-style bg=#2c323c # For Vim One colorscheme
-
-# Status bar settings
-set -g status-left-length 60
-set -g status-left "#[fg=green][#S] #[fg=red]w#I #[fg=blue]p#P"
-set -g status-right-length 60
-set -g status-right " #[fg=white]%a, %b %d | %H:%M "
-set -g status-interval 15 # default is 15
-set -g status-justify centre
 
 # vim: set filetype=tmux:

--- a/tmux.conf
+++ b/tmux.conf
@@ -1,5 +1,26 @@
 # ~/.tmux.conf
 
+# Colors {{{
+# https://leanpub.com/the-tao-of-tmux/read#leanpub-auto-styling
+
+BLACK="black"
+BLUE="blue"
+CYAN="cyan"
+GREEN="green"
+MAGENTA="magenta"
+RED="red"
+WHITE="white"
+YELLOW="yellow"
+
+BRIGHT_BLUE="brightblue"
+BRIGHT_CYAN="brightcyan"
+BRIGHT_GREEN="brightgreen"
+BRIGHT_MAGENTA="brightmagenta"
+BRIGHT_RED="brightred"
+BRIGHT_YELLOW="brightyellow"
+
+# }}}
+
 # Bindings {{{
 
 # Reload the file with prefix r

--- a/tmux.conf
+++ b/tmux.conf
@@ -156,16 +156,16 @@ set-option -g history-limit 5000
 # Window/Pane Appearance {{{
 
 # set the color of the window list
-setw -g window-status-style fg=black,bg=colour12
+setw -g window-status-style fg=$BLACK,bg=$BLUE
 
 # set colors for the active window
-setw -g window-status-current-style fg=white,bg=red,bright
+setw -g window-status-current-style fg=$WHITE,bg=$BRIGHT_RED
 
 # pane colors
 set -g pane-border-style bg=default,fg=default
-set -g pane-active-border-style bg=default,fg=blue
+set -g pane-active-border-style bg=default,fg=$BLUE
 
-set -g message-style fg=white,bg=black
+set -g message-style fg=$WHITE,bg=$BLACK
 
 # }}}
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -165,13 +165,32 @@ setw -g window-status-current-style fg=$WHITE,bg=$BRIGHT_RED
 set -g pane-border-style bg=default,fg=default
 set -g pane-active-border-style bg=default,fg=$BLUE
 
+# Tmux prompt colors
 set -g message-style fg=$WHITE,bg=$BLACK
 
 # }}}
 
 # Status bar {{{
 
-source-file $DOTFILES/machines/$HOST_NAME/tmux.conf.status-bar
+# Enable UTF-8 support in status bar
+set -g status on
+
+# Status bar settings
+set -g status-left-length 60
+set -g status-left "#[fg=$GREEN][#S] #[fg=$RED]w#I #[fg=$BLUE]p#P"
+set -g status-right-length 60
+set -g status-right " #[fg=$WHITE]%a, %b %d | %H:%M "
+set -g status-interval 15 # default is 15
+set -g status-justify centre
+
+# Status bar background color.
+set -g status-style bg=$BLACK
+
+# }}}
+
+# Custom overrides {{{
+
+source-file $DOTFILES/machines/$HOST_NAME/tmux.conf.custom
 
 # }}}
 


### PR DESCRIPTION
In this PR, I'm taking a slightly different approach to machine-specific configs. Mostly this comes down to color choices that fit better with a given colorscheme. Instead of overriding color variables (which seems behave a bit oddly) I'm re-declaring settings in `machines/$HOST_NAME/tmux.conf.custom`.