### PR TITLE
fix: Symlink default-mac Brewfile to relative path

### DIFF
--- a/machines/default-mac/Brewfile
+++ b/machines/default-mac/Brewfile
@@ -1,1 +1,1 @@
-/Users/joshukraine/dotfiles/Brewfile
+../../Brewfile


### PR DESCRIPTION
It is now symlinked to your user folder.
Symlink it to the project root Brewfile (like the other machine specific symlinks).