### PR TITLE
Load iTerm2 Prefs from Console

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -163,6 +163,14 @@ if [ ! -d "${HOME}/.terminfo" ]; then
   tic -x "${DOTFILES}/terminfo/xterm-256color-italic.terminfo"
 fi
 
+if [ -d "/Applications/iTerm.app" ]; then
+  # Specify the preferences directory
+  defaults write com.googlecode.iterm2.plist PrefsCustomFolder -string "$DOTFILES/iterm"
+
+  # Tell iTerm2 to use the custom preferences in the directory
+  defaults write com.googlecode.iterm2.plist LoadPrefsFromCustomFolder -bool true
+fi
+
 dotfiles_echo "Dotfiles setup complete!"
 echo
 echo "Possible next steps:"

--- a/setup.sh
+++ b/setup.sh
@@ -29,8 +29,7 @@ if [ "$osname" != "Darwin" ]; then
 fi
 
 if ! command -v stow >/dev/null; then
-  dotfiles_echo "GNU Stow is required but was not found. Try:"
-  dotfiles_echo "brew install stow"
+  dotfiles_echo "GNU Stow is required but was not found. Try: brew install stow"
   dotfiles_echo "Exiting..."
   exit 1
 fi
@@ -164,6 +163,8 @@ if [ ! -d "${HOME}/.terminfo" ]; then
 fi
 
 if [ -d "/Applications/iTerm.app" ]; then
+  dotfiles_echo "Setting up iTerm2 preferences..."
+
   # Specify the preferences directory
   defaults write com.googlecode.iterm2.plist PrefsCustomFolder -string "$DOTFILES/iterm"
 
@@ -177,5 +178,4 @@ echo "Possible next steps:"
 echo "-> Install LunarVim (https://www.lunarvim.org)"
 echo "-> Install Zap (https://www.zapzsh.org)"
 echo "-> Install Homebrew packages (brew bundle install)"
-echo "-> Set up iTerm2 preferences (Settings > General > Preferences)"
 echo


### PR DESCRIPTION
This PR implements loading custom iTerm2 preferences from within the `setup.sh` script as explained in a [blog post by Trevor Brown](http://stratus3d.com/blog/2015/02/28/sync-iterm2-profile-with-dotfiles-repository/).

Closes issue #54 