### PR TITLE
fix: remove outdated readlink -f compatibility restrictions for modern macOS

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,9 +1,9 @@
 # ShellCheck configuration for dotfiles project
 # https://www.shellcheck.net/wiki/Ignore
 #
-# IMPORTANT: This project targets macOS
-# - Avoid Linux-specific commands (e.g., readlink -f)
-# - Use POSIX-compatible alternatives where possible
+# IMPORTANT: This project targets macOS (12.3+)
+# - readlink -f is supported on macOS 12.3 Monterey and later
+# - Use POSIX-compatible alternatives for broader compatibility when needed
 
 # Set shell for shell-specific checks (default to bash)
 shell=bash

--- a/scripts/lint-shell
+++ b/scripts/lint-shell
@@ -214,13 +214,6 @@ lint_file() {
     return 0
   fi
 
-  # Check for macOS-incompatible patterns (exclude comments and strings)
-  if grep -E '^\s*[^#]*readlink\s+-f' "${file}" 2>/dev/null | grep -v "grep.*readlink" | grep -v "contains.*readlink" >/dev/null; then
-    echo "❌ ERROR: ${file} contains 'readlink -f' which is not compatible with macOS!" >&2
-    echo "   Use this pattern instead: \$(cd \"\$(dirname \"\${BASH_SOURCE[0]}\")\" && pwd)/\$(basename \"\${BASH_SOURCE[0]}\")" >&2
-    EXIT_CODE=1
-  fi
-
   # Run shfmt if requested
   if [[ "${CHECK_MODE}" == "true" ]] || [[ "${FIX_MODE}" == "true" ]]; then
     local shfmt_args=()


### PR DESCRIPTION
## Summary

- Remove outdated readlink -f compatibility restrictions for modern macOS systems
- Update documentation to reflect macOS 12.3+ support for readlink -f
- Allow developers to use readlink -f natively without workarounds

## Background

Apple added the `-f` flag to `readlink` in macOS 12.3 Monterey (March 2022). Our codebase incorrectly assumed this functionality was not available, forcing developers to use unnecessary workarounds like `realpath` or `greadlink`.

## Changes Made

1. **Updated `.shellcheckrc`** - Modified comment to reflect current macOS 12.3+ compatibility
2. **Removed lint restriction** - Deleted code in `scripts/lint-shell` that blocked `readlink -f` usage

## Testing

- ✅ Lint script runs without errors related to readlink -f
- ✅ Verified readlink -f works correctly on macOS 15.5
- ✅ All pre-commit hooks pass
- ✅ No breaking changes to existing functionality

## Impact

- Developers can now use `readlink -f` natively on modern macOS systems
- Reduces code complexity by eliminating unnecessary workarounds
- Maintains backward compatibility for existing workarounds

**Fixes #91**