### PR TITLE
docs: remove broken agent assistance references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,6 @@ Some directories contain repository infrastructure and should not be symlinked t
 
 **Example directories using this pattern:**
 
-- `agents/` - Claude Code sub-agents documentation
 - `docs/` - Repository documentation
 - `scripts/` - Build and utility scripts
 - `tests/` - Test files and fixtures

--- a/docs/setup/troubleshooting.md
+++ b/docs/setup/troubleshooting.md
@@ -621,17 +621,6 @@ ls -la ~/.zshrc
 
 ## 🆘 Getting Additional Help
 
-### Specialized Agent Assistance
-
-For targeted help with specific aspects of the dotfiles, use the appropriate specialized agent:
-
-| Issue Type                                 | Recommended Agent                                                   | What They Help With                                          |
-| ------------------------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------ |
-| **Stow conflicts, package management**     | **[🔧 Config Manager](../../agents/config-manager.md)**             | Dotfiles structure, Stow operations, symlink troubleshooting |
-| **Abbreviations not working, shell setup** | **[⚡ Abbreviation Manager](../../agents/abbreviation-manager.md)** | YAML abbreviation system, Fish/Zsh sync issues               |
-| **Test failures, validation errors**       | **[✅ Test Validator](../../agents/test-validator.md)**             | Running tests, linting, pre-commit hook setup                |
-| **Documentation outdated or unclear**      | **[📚 Documentation Helper](../../agents/docs-helper.md)**          | Updating guides, fixing examples, troubleshooting docs       |
-
 ### General Troubleshooting Steps
 
 If your issue isn't covered here:

--- a/docs/setup/troubleshooting.md
+++ b/docs/setup/troubleshooting.md
@@ -85,8 +85,6 @@ mkdir: /Users/username/.config: Permission denied
 
 ## 🔗 Stow and Symlink Problems
 
-> 💡 **Agent Assistance**: For complex Stow and symlink issues, consider using the **[Config Manager Agent](../../agents/config-manager.md)** for specialized help with dotfiles structure and Stow package management.
-
 ### Stow Command Not Found
 
 **Problem**: `stow: command not found`
@@ -259,8 +257,6 @@ ls -la ~/.zshrc
    ```
 
 ## 🐚 Shell Configuration Problems
-
-> 💡 **Agent Assistance**: For abbreviation and shell configuration issues, the **[Abbreviation Manager Agent](../../agents/abbreviation-manager.md)** can help with YAML-based abbreviation system troubleshooting.
 
 ### New Terminal Doesn't Load Dotfiles Configuration
 


### PR DESCRIPTION
## Summary

- Remove broken references to Claude Code agents that were left behind after `agents/` directory removal
- Clean up documentation to eliminate broken links and outdated guidance
- Restore documentation coherence after agent system removal

## Changes

**Documentation cleanup:**
- Remove "💡 **Agent Assistance**" callouts from troubleshooting guide (2 instances)
- Remove entire "Specialized Agent Assistance" section with table of broken agent links
- Update CLAUDE.md stow ignore examples to remove `agents/` directory reference

**Files modified:**
- `docs/setup/troubleshooting.md` - Removed agent callouts and assistance section
- `CLAUDE.md` - Updated stow ignore directory examples

## Testing

- [x] Markdown validation passes for all documentation files
- [x] Grep verification confirms all broken agent references removed
- [x] Documentation remains coherent and readable after removals
- [x] No broken links or orphaned text sections

Closes #99