### PR TITLE
feat(claude): add context-bridge slash command for session continuity

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,18 +353,21 @@ This project includes comprehensive [Claude Code][claude-code] integration for A
 
 ### Available Commands
 
-| Command           | Description                                                   |
-| ----------------- | ------------------------------------------------------------- |
-| `/commit`         | Create commits with clipboard workflow (no attribution)       |
-| `/commit-auto`    | Create commits with full automation (includes attribution)    |
-| `/create-pr`      | Generate comprehensive pull requests with smart issue linking |
-| `/resolve-issue`  | Systematic GitHub issue resolution workflow                   |
-| `/review-pr`      | Thorough pull request reviews with configurable depth         |
-| `/setup-scratch`  | Initialize temporary workspace for development notes          |
-| `/new-project`    | Comprehensive project setup (use after Claude Code's `/init`) |
-| `/update-deps`    | Safe dependency updates with testing                          |
-| `/save-knowledge` | Capture session insights into structured knowledge base       |
-| `/process-inbox`  | Process web content into organized knowledge base entries     |
+| Command            | Description                                                   |
+| ------------------ | ------------------------------------------------------------- |
+| `/commit`          | Create commits with clipboard workflow (no attribution)       |
+| `/commit-auto`     | Create commits with full automation (includes attribution)    |
+| `/commit-msg`      | Generate commit messages from staged changes                  |
+| `/context-bridge`  | Create session continuity documents for Claude Code           |
+| `/create-pr`       | Generate comprehensive pull requests with smart issue linking |
+| `/resolve-issue`   | Systematic GitHub issue resolution workflow                   |
+| `/review-pr`       | Thorough pull request reviews with configurable depth         |
+| `/setup-scratch`   | Initialize temporary workspace for development notes          |
+| `/new-project`     | Comprehensive project setup (use after Claude Code's `/init`) |
+| `/update-deps`     | Safe dependency updates with testing                          |
+| `/save-knowledge`  | Capture session insights into structured knowledge base       |
+| `/process-inbox`   | Process web content into organized knowledge base entries     |
+| `/help`            | Display available commands with usage examples                |
 
 ### Getting Started with Claude Code
 

--- a/claude/.claude/commands/context-bridge.md
+++ b/claude/.claude/commands/context-bridge.md
@@ -107,6 +107,8 @@ git checkout [branch_name]
 
 [One paragraph with essential context for resuming work]
 
+**IMPORTANT**: This is a context bridge only. Wait for explicit user confirmation before starting any implementation or making changes.
+
 ### Testing/Verification
 
 - [Key test command or verification step]
@@ -135,7 +137,7 @@ Key points for continuation:
 - [Active focus area]
 - [Next immediate task]
 
-Please review the bridge document and confirm you understand the current state, then help me continue with [SPECIFIC_NEXT_ACTION].
+Please review the bridge document and confirm you understand the current state. Once you've reviewed it, wait for my confirmation before taking any action. Do not start implementing or making changes until I explicitly ask you to proceed.
 
 Working directory: [CURRENT_DIRECTORY]
 ```

--- a/claude/.claude/commands/context-bridge.md
+++ b/claude/.claude/commands/context-bridge.md
@@ -1,0 +1,138 @@
+# Context Bridge Command
+
+Create a session bridge document to continue work in a new Claude Code session.
+
+## Usage
+
+```bash
+/context-bridge [description]
+```
+
+## Your Task
+
+1. **Analyze recent conversation** to understand project context and progress
+2. **Create bridge document** at `scratchpads/context-bridge-YYYY-MM-DD-HHMMSS-[description].md`
+3. **Copy continuation prompt** to clipboard with `pbcopy`
+4. **Display confirmation** with file location and copied prompt
+
+## Bridge Document Template
+
+````markdown
+# Claude Code Context Bridge - [Project/Task Name]
+
+**Created**: YYYY-MM-DD HH:MM:SS
+**Session**: Context bridge for continuing work
+**Next Steps**: [Immediate next action]
+
+## Current Project Overview
+
+### Main Objective
+
+[What we're trying to accomplish]
+
+### Current Status
+
+[Current phase: X% complete - brief status]
+
+### Active Branch/Repository
+
+```bash
+cd [repository_path]
+git checkout [branch_name]
+```
+
+## Key Context
+
+### Technologies/Tools Involved
+
+- [List only essential technologies being used]
+
+### Important Files/Locations
+
+- **Primary config**: `[main_config_file]`
+- **Working directory**: `[current_directory]`
+- **Test files**: `[test_files]` (if applicable)
+
+### Current Configuration State
+
+```[language]
+[Key configuration snippet - only if essential]
+```
+
+## Recent Progress Summary
+
+### Completed Items ✅
+
+1. [Major accomplishments]
+2. [Key implementations]
+
+### In Progress ⏳
+
+- [Current task being worked on]
+
+### Next Tasks 📋
+
+1. [Immediate next step]
+2. [Following tasks]
+
+## Technical Details
+
+### Key Insights/Discoveries
+
+- [Critical findings that affect implementation]
+- [Important gotchas to remember]
+
+### Commands Used
+
+```bash
+[Essential commands for testing/running the project]
+```
+
+### File Changes Made
+
+- [Files modified/created - only list significant ones]
+
+## Continuation Instructions
+
+### Immediate Resume Steps
+
+1. [First action to take]
+2. [How to verify current state]
+3. [What to focus on next]
+
+### Context for New Session
+
+[One paragraph with essential context for resuming work]
+
+### Testing/Verification
+
+- [Key test command or verification step]
+
+## Additional Notes
+
+[Any critical warnings or blockers - only if necessary]
+
+````
+
+## Continuation Prompt Template
+
+```text
+I'm continuing work on [PROJECT_NAME] from a previous Claude Code session. Please read the context bridge document at:
+
+[BRIDGE_FILE_PATH]
+
+This document contains:
+- Complete project overview and current status
+- Technical details and configuration states
+- Recent progress and next steps
+- All necessary context to resume work seamlessly
+
+Key points for continuation:
+- [Current status in one line]
+- [Active focus area]
+- [Next immediate task]
+
+Please review the bridge document and confirm you understand the current state, then help me continue with [SPECIFIC_NEXT_ACTION].
+
+Working directory: [CURRENT_DIRECTORY]
+```

--- a/claude/.claude/commands/context-bridge.md
+++ b/claude/.claude/commands/context-bridge.md
@@ -5,13 +5,16 @@ Create a session bridge document to continue work in a new Claude Code session.
 ## Usage
 
 ```bash
-/context-bridge [description]
+/context-bridge              # Auto-generated filename with timestamp only
+/context-bridge description  # Custom description added to filename
 ```
 
 ## Your Task
 
 1. **Analyze recent conversation** to understand project context and progress
-2. **Create bridge document** at `scratchpads/context-bridge-YYYY-MM-DD-HHMMSS-[description].md`
+2. **Create bridge document** at:
+   - With description: `scratchpads/context-bridge-YYYY-MM-DD-HHMMSS-description.md`
+   - Without description: `scratchpads/context-bridge-YYYY-MM-DD-HHMMSS.md`
 3. **Copy continuation prompt** to clipboard with `pbcopy`
 4. **Display confirmation** with file location and copied prompt
 

--- a/claude/.claude/commands/help.md
+++ b/claude/.claude/commands/help.md
@@ -27,6 +27,8 @@ Display available Claude Code commands and their usage.
 ### Git & GitHub Workflows
 
 - `/commit` - Create well-formatted commits with guided workflow
+- `/commit-auto` - Create commits with full automation (includes attribution)
+- `/commit-msg` - Generate commit messages from staged changes
 - `/create-pr` - Create pull requests with smart titles and issue linking
 - `/resolve-issue` - Resolve GitHub issues systematically
 - `/review-pr` - Review pull requests with configurable depth
@@ -36,6 +38,12 @@ Display available Claude Code commands and their usage.
 - `/setup-scratch` - Initialize temporary workspace for notes and debugging
 - `/new-project` - Comprehensive project setup (use after Claude Code's `/init`)
 - `/update-deps` - Update dependencies safely across package managers
+- `/context-bridge` - Create session continuity documents for Claude Code
+
+### Knowledge Management
+
+- `/save-knowledge` - Capture session insights into structured knowledge base
+- `/process-inbox` - Process web content into organized knowledge base entries
 
 ### Development Tools
 
@@ -51,6 +59,8 @@ Claude Code Commands
 
 Git & GitHub:
   /commit              - Create well-formatted commits
+  /commit-auto         - Create commits with full automation
+  /commit-msg          - Generate commit messages from staged changes
   /create-pr           - Create pull requests with smart titles
   /resolve-issue       - Resolve GitHub issues systematically
   /review-pr           - Review pull requests thoroughly
@@ -59,6 +69,11 @@ Project Management:
   /setup-scratch       - Initialize temporary workspace
   /new-project         - Comprehensive project setup (use after /init)
   /update-deps         - Update dependencies safely
+  /context-bridge      - Create session continuity documents
+
+Knowledge Management:
+  /save-knowledge      - Capture session insights
+  /process-inbox       - Process web content into knowledge base
 
 Use '/help <command>' for detailed information about a specific command.
 ```
@@ -92,6 +107,12 @@ Git & GitHub Commands
 /commit
   Create well-formatted commits with guided workflow
   Options: --no-verify
+
+/commit-auto
+  Create commits with full automation (includes attribution)
+
+/commit-msg
+  Generate commit messages from staged changes
 
 /create-pr
   Create pull requests with smart titles and issue linking


### PR DESCRIPTION
## Summary
Add a concise context-bridge slash command to help maintain continuity when starting new Claude Code sessions due to context limits. The command creates timestamped bridge documents that capture essential project state and progress.

## Features
- **Automatic context analysis** - Analyzes recent conversation to extract key information
- **Concise template structure** - 40% smaller than original design while maintaining functionality
- **Flexible usage** - Can be used with or without description parameter
- **Explicit confirmation requirement** - New sessions wait for user approval before taking action
- **Clipboard integration** - Copies continuation prompt for easy pasting

## Usage
```bash
/context-bridge              # Creates bridge document with timestamp only
/context-bridge description  # Adds custom description to filename
```

## Implementation Details
- Bridge documents saved to `scratchpads/` directory (gitignored)
- Filename format: `context-bridge-YYYY-MM-DD-HHMMSS[-description].md`
- Includes comprehensive template for capturing project state
- Generates ready-to-use continuation prompt with explicit wait instructions

## Notes
- No linked issue - this is a standalone enhancement
- Addresses the need for better session continuity management
- Prevents new sessions from automatically starting work without confirmation

🤖 Generated with [Claude Code](https://claude.ai/code)