### PR TITLE
fix: remove Docker aliases that conflict with abbreviations

### DIFF
--- a/zsh/.config/zsh/docker.sh
+++ b/zsh/.config/zsh/docker.sh
@@ -7,21 +7,13 @@
 #                                                                          #
 #     # Usage:                                                             #
 #     daws <svc> <cmd> <opts> : aws cli in docker with <svc> <cmd> <opts>  #
-#     dc             : docker compose                                      #
-#     dcu            : docker compose up -d                                #
-#     dcd            : docker compose down                                 #
-#     dcr            : docker compose run                                  #
 #     dex <container>: execute a bash shell inside the RUNNING <container> #
 #     di <container> : docker inspect <container>                          #
-#     dim            : docker images                                       #
 #     dip            : IP addresses of all running containers              #
-#     dl <container> : docker logs -f <container>                          #
+#     dlab           : docker ps filtered by label                         #
 #     dnames         : names of all running containers                     #
-#     dps            : docker ps                                           #
-#     dpsa           : docker ps -a                                        #
 #     drmc           : remove all exited containers                        #
 #     drmid          : remove all dangling images                          #
-#     drun <image>   : execute a bash shell in NEW container from <image>  #
 #     dsr <container>: stop then remove <container>                        #
 #                                                                          #
 ############################################################################
@@ -51,18 +43,6 @@ function di-fn {
   docker inspect "$1"
 }
 
-function dl-fn {
-  docker logs -f "$1"
-}
-
-function drun-fn {
-  docker run -it "$1" "$2"
-}
-
-function dcr-fn {
-  docker compose run "$@"
-}
-
 function dsr-fn {
   docker stop "$1"
   docker rm "$1"
@@ -82,10 +62,6 @@ function dlab {
   docker ps --filter="label=$1" --format="{{.ID}}"
 }
 
-function dc-fn {
-  docker compose "$*"
-}
-
 function d-aws-cli-fn {
   docker run \
     -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
@@ -94,22 +70,11 @@ function d-aws-cli-fn {
     amazon/aws-cli:latest "$1" "$2" "$3"
 }
 
-# Disabled aliases have equivalent zsh abbreviations
 alias daws=d-aws-cli-fn
-alias dc=dc-fn
-# alias dcu="docker compose up -d"
-# alias dcd="docker compose down"
-alias dcr=dcr-fn
 alias dex=dex-fn
 alias di=di-fn
-# alias dim="docker images"
 alias dip=dip-fn
-alias dl=dl-fn
 alias dnames=dnames-fn
-# alias dps="docker ps"
-# alias dpsa="docker ps -a"
 alias drmc=drmc-fn
 alias drmid=drmid-fn
-alias drun=drun-fn
-# alias dsp="docker system prune --all"
 alias dsr=dsr-fn


### PR DESCRIPTION
## Summary

- Remove Docker aliases and wrapper functions from `docker.sh` that conflict with abbreviations in `abbreviations.zsh`
- Fix the `dcr` semantic conflict where the alias expanded to `docker compose run` but the abbreviation expands to `docker compose restart`
- Fix the `$*` bug in `dc-fn` (joined all arguments into a single string instead of preserving them)

## Changes

- Removed 4 conflicting wrapper functions: `dc-fn`, `dcr-fn`, `dl-fn`, `drun-fn`
- Removed 4 conflicting aliases: `dc`, `dcr`, `dl`, `drun`
- Removed commented-out dead aliases (`dcu`, `dcd`, `dim`, `dps`, `dpsa`, `dsp`)
- Updated header comment to reflect only the remaining commands
- Kept aliases/functions that have no abbreviation equivalent and provide non-trivial argument handling (`dex`, `di`, `dip`, `dsr`, `dnames`, `drmc`, `drmid`, `dlab`, `daws`)

## Testing

- [x] All 62 bats tests pass
- [x] Shell linting passes (shellcheck)
- [x] Pre-commit hooks pass

Closes #136