### PR TITLE
feat: configure neotest-minitest for Rails projects

### DIFF
--- a/nvim/.config/nvim/lua/plugins/extend-neotest.lua
+++ b/nvim/.config/nvim/lua/plugins/extend-neotest.lua
@@ -12,20 +12,20 @@ return {
       adapters = {
         ["neotest-minitest"] = {
           test_cmd = function()
-            return vim.tbl_flatten({
+            return {
               "bundle",
               "exec",
               "rails",
               "test",
-            })
+            }
           end,
 
           -- Docker: Uncomment the block below (and comment out test_cmd above)
-          -- to run minitest inside a Docker container via docker-compose.
+          -- to run minitest inside a Docker container via docker compose.
           -- Adjust the service name ("app") and working directory as needed.
           --
           -- test_cmd = function()
-          --   return vim.tbl_flatten({
+          --   return {
           --     "docker",
           --     "compose",
           --     "exec",
@@ -37,7 +37,7 @@ return {
           --     "exec",
           --     "rails",
           --     "test",
-          --   })
+          --   }
           -- end,
           --
           -- transform_spec_path = function(path)


### PR DESCRIPTION
## Summary

Closes #148

- Remove redundant dependencies and duplicate rspec adapter config already provided by LazyVim's `test.core` and `lang.ruby` extras
- Activate minitest adapter with the correct `test_cmd` option (`bundle exec rails test`)
- Add documented Docker Compose config as comments for future container-based projects

## Test plan

- [ ] Open Neovim and run `:Lazy sync` — no errors
- [ ] In a Rails/minitest project, press `<leader>tr` — runs via `bundle exec rails test`
- [ ] Verify adapters: `:lua for _, a in ipairs(require("neotest").adapters) do print(a.name) end` — shows both `neotest-rspec` and `neotest-minitest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)