### PR TITLE
fix: disable Ruby LSP Rails pending migrations prompt

### DIFF
--- a/nvim/.config/nvim/lua/plugins/extend-nvim-lspconfig.lua
+++ b/nvim/.config/nvim/lua/plugins/extend-nvim-lspconfig.lua
@@ -16,6 +16,13 @@ return {
       ruby_lsp = {
         mason = false,
         cmd = { vim.fn.expand("~/.asdf/shims/ruby-lsp") },
+        init_options = {
+          addonSettings = {
+            ["Ruby LSP Rails"] = {
+              enablePendingMigrationsPrompt = false,
+            },
+          },
+        },
       },
       -- https://github.com/standardrb/standard
       standardrb = {


### PR DESCRIPTION
## Summary

Closes #150

- Add `init_options` to `ruby_lsp` server config to disable the intrusive pending migrations popup from ruby-lsp-rails
- Uses the `enablePendingMigrationsPrompt` setting added in [Shopify/ruby-lsp-rails#570](https://github.com/Shopify/ruby-lsp-rails/pull/570)

## Test plan

- [ ] Open Neovim in a Rails project with pending migrations — popup should no longer appear
- [ ] Verify Ruby LSP still starts and provides completions/diagnostics normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)