### PR TITLE
chore: replace git checkout with git switch

### DIFF
--- a/claude/.claude/commands/resolve-issue.md
+++ b/claude/.claude/commands/resolve-issue.md
@@ -28,7 +28,7 @@ Track your progress through the 6 steps below. Report completion of each step be
 
 ### Step 4: Create branch and implement
 
-- Create feature branch: `git checkout -b fix/gh-$ARGUMENTS` or `feat/gh-$ARGUMENTS`
+- Create feature branch: `git switch -c fix/gh-$ARGUMENTS` or `feat/gh-$ARGUMENTS`
 - Verify branch: `git branch --show-current`
 - Implement with frequent commits (see commit strategy below)
 - **Do NOT include issue references** in commit messages


### PR DESCRIPTION
## Summary

- Replace `git checkout -b` with `git switch -c` in the resolve-issue Claude command
- Update local permissions allowlist from `git checkout` to `git switch`

## Changes

- `claude/.claude/commands/resolve-issue.md`: Use modern `git switch -c` for branch creation
- `.claude/settings.local.json`: Updated locally (gitignored, not committed)

## Testing

- [x] Pre-commit hooks pass (markdownlint, trailing whitespace, etc.)
- [x] No remaining `git checkout` references in `claude/` directory
- [x] `git switch -c` syntax verified correct

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)