### PR TITLE
feat: add setup-repo bootstrap script

### DIFF
--- a/bin/.local/bin/setup-repo
+++ b/bin/.local/bin/setup-repo
@@ -18,9 +18,9 @@
 #
 # Reference repo for label colors:
 #   Labels are cloned from a reference repo to ensure consistent colors.
-#   Set SETUP_REPO_REFERENCE to override (default: joshukraine/comixdistro).
+#   Set SETUP_REPO_REFERENCE to override (default: joshukraine/comix_distro).
 #
-# Requirements: gh CLI (authenticated), jq
+# Requirements: bash 4+ (associative arrays, ${var^}), gh CLI (authenticated), jq
 
 set -euo pipefail
 
@@ -94,10 +94,16 @@ for arg in "$@"; do
   case "${arg}" in
     --dry-run) DRY_RUN=true ;;
     --help | -h)
-      sed -n '2,/^$/s/^# //p' "$0"
+      sed -n '2,/^# Requirements/s/^# \{0,1\}//p' "$0"
       exit 0
       ;;
-    *) TARGET_REPO="${arg}" ;;
+    *)
+      if [[ -n "${TARGET_REPO}" ]]; then
+        error "Multiple repositories specified: ${TARGET_REPO} and ${arg}"
+        exit 1
+      fi
+      TARGET_REPO="${arg}"
+      ;;
   esac
 done
 
@@ -282,6 +288,12 @@ else
       PROJECT_NUMBER=""
     fi
   fi
+fi
+
+# Validate PROJECT_NUMBER is numeric (guard against unexpected gh output)
+if [[ -n "${PROJECT_NUMBER}" && "${PROJECT_NUMBER}" != "DRY_RUN" && ! "${PROJECT_NUMBER}" =~ ^[0-9]+$ ]]; then
+  warn "Invalid project number: ${PROJECT_NUMBER}. Skipping project setup."
+  PROJECT_NUMBER=""
 fi
 
 # --- Step 6: Add Priority field to project -----------------------------------


### PR DESCRIPTION
## Summary

- Adds `setup-repo`, a Bash script that bootstraps new GitHub repositories with a unified label taxonomy and project board configuration
- Removes GitHub default labels (bug, enhancement, etc.) and creates work-type labels (feat, fix, chore, docs, test) plus triage labels, cloning colors from a reference repo
- Creates a GitHub Project board with a Priority custom field (Critical/Normal/Low) and links it to the repository
- Supports `--dry-run` mode for previewing changes and auto-detects the repo from the current directory

## Test plan

- [ ] Run `setup-repo --dry-run` from inside a git repo to verify dry-run output
- [ ] Run `setup-repo owner/repo --dry-run` with an explicit repo argument
- [ ] Run `setup-repo --help` to verify usage output
- [ ] Run against a test repository to verify label creation/removal and project board setup
- [ ] Verify `shellcheck` and `./scripts/lint-shell` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)