### PR TITLE
chore(claude): migrate commands to skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - [Starship][starship] prompt
 - [Zsh][zsh] shell with [zsh-abbr][zsh-abbr] for abbreviations
 - Flexible, terminal-based dev environment with [ghostty][ghostty] 👻 + [Tmux][tmux]!
-- [Claude Code][claude-code] with custom commands, permission presets, and safety hooks
+- [Claude Code][claude-code] with custom skills, permission presets, and safety hooks
 - Fast, idempotent setup with [GNU Stow][gnu-stow]
 - New Mac bootstrap based on thoughtbot's [Laptop][laptop]
 - Support for both Apple Silicon and Intel Macs
@@ -226,12 +226,12 @@ These functions work with both `main` and `master` branch names automatically.
 > [!TIP]
 > Claude Code can also run inside Neovim via the [claude-code.nvim][claude-code-nvim] plugin, which is how I use it most of the time during development.
 
-### Custom Commands
+### Skills
 
-Slash commands provide structured workflows for the full development lifecycle:
+Custom [skills][agent-skills] provide structured workflows for the full development lifecycle:
 
-| Command | Purpose |
-| ------- | ------- |
+| Skill | Purpose |
+| ----- | ------- |
 | `/bootstrap-prd` | Scaffold PRD-driven development infrastructure into a new project |
 | `/checkpoint` | Quick status update — what's done, in progress, and blocked |
 | `/commit` | Analyze diffs, split into logical commits, Conventional Commits format |
@@ -460,6 +460,7 @@ Copyright &copy; 2014–2026 Joshua Steele. [MIT License][license]
 
 [1p-cli-ssh]: https://developer.1password.com/docs/ssh
 [1p-cli-start]: https://developer.1password.com/docs/cli/get-started
+[agent-skills]: https://agentskills.io
 [asdf]: https://asdf-vm.com/
 [claude-code]: https://docs.anthropic.com/en/docs/claude-code/overview
 [claude-code-nvim]: https://github.com/coder/claudecode.nvim

--- a/bin/.local/bin/setup-repo
+++ b/bin/.local/bin/setup-repo
@@ -400,7 +400,7 @@ echo "       • Pull request merged    → Set status to Done"
 echo "       • Item closed            → Set status to Done"
 echo "       • Item reopened          → Set status to In Progress"
 echo ""
-echo -e "  3. ${BOLD}Copy CLAUDE.md and slash commands${NC} to the new repo"
+echo -e "  3. ${BOLD}Copy CLAUDE.md and skills${NC} to the new repo"
 echo "     (These live in your dotfiles and are already portable.)"
 echo ""
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -47,7 +47,7 @@ Projects with a Product Requirements Document (PRD) follow these conventions:
 - **Cross-references**: Use `→ See 07-feature.md §3 "Section Heading"` format between PRD files. Always include the filename and quoted heading — never bare `§N`.
 - **Templates**: Starter templates for new projects live in `~/.claude/docs/prd-workflow/templates/` — PRD files and project CLAUDE.md.
 - **Shared docs**: `~/.claude/docs/label-taxonomy.md` provides project-agnostic references for labeling conventions and branch naming.
-- **Full workflow**: See `~/.claude/docs/README.md` for the document index. The spec-driven development handbook (`~/.claude/docs/prd-workflow/spec-driven-development.md`) covers deviation thresholds, checkpoint cadence, document lifecycle, and the slash command map.
+- **Full workflow**: See `~/.claude/docs/README.md` for the document index. The spec-driven development handbook (`~/.claude/docs/prd-workflow/spec-driven-development.md`) covers deviation thresholds, checkpoint cadence, document lifecycle, and the skill map.
 
 ## Git Workflow
 
@@ -90,4 +90,4 @@ Constraint: Do not use `$(...)`, backticks, or complex shell nesting for commits
 
 ---
 
-Type `/` to see available slash commands for common workflows.
+Type `/` to see available skills for common workflows.

--- a/claude/.claude/cheatsheet.md
+++ b/claude/.claude/cheatsheet.md
@@ -1,6 +1,6 @@
 # Claude Code Cheatsheet
 
-*Last updated: 2026-03-01* <!-- Update this date when editing this file -->
+*Last updated: 2026-03-26* <!-- Update this date when editing this file -->
 
 Quick reference for usage tips, keyboard shortcuts, and workflow habits.
 
@@ -27,17 +27,17 @@ Quick reference for usage tips, keyboard shortcuts, and workflow habits.
 | `/sandbox` | Enable OS-level filesystem and network sandboxing |
 | `/simplify` | Review changed code for reuse, quality, and efficiency |
 
-## Custom Commands
+## Skills (Custom Commands)
 
-| Command | When to use |
-| ------- | ----------- |
+| Skill | When to use |
+| ----- | ----------- |
 | `/resolve-issue 123` | Full workflow for a GitHub issue — research, plan, implement, verify |
 | `/sprint-issue 123` | Fast-track a small, well-scoped issue — skips the plan checkpoint |
 | `/commit` | Stage and commit with smart splitting and Conventional Commits |
 | `/create-pr` | Create a PR with auto-generated description and issue linking (inferred from branch name) |
 | `/simplify` | Post-implementation code review — run before creating a PR |
 
-All custom commands live in `claude/.claude/commands/`. Type `/` to browse the full list including PRD-specific commands (`/bootstrap-prd`, `/plan-phase`, `/setup-sprint`, `/debrief`, etc.).
+All skills live in `claude/.claude/skills/`. Type `/` to browse the full list including PRD-specific skills (`/bootstrap-prd`, `/plan-phase`, `/setup-sprint`, `/debrief`, etc.).
 
 ### Common Workflow
 
@@ -64,4 +64,4 @@ All custom commands live in `claude/.claude/commands/`. Type `/` to browse the f
 
 ## Weekly Habit
 
-Run `/insights` once a week. When it surfaces a pattern, act on it: add a rule to CLAUDE.md, write a hook, or extract a repeated workflow into a command.
+Run `/insights` once a week. When it surfaces a pattern, act on it: add a rule to CLAUDE.md, write a hook, or extract a repeated workflow into a skill.

--- a/claude/.claude/cheatsheet.md
+++ b/claude/.claude/cheatsheet.md
@@ -27,7 +27,7 @@ Quick reference for usage tips, keyboard shortcuts, and workflow habits.
 | `/sandbox` | Enable OS-level filesystem and network sandboxing |
 | `/simplify` | Review changed code for reuse, quality, and efficiency |
 
-## Skills (Custom Commands)
+## Skills
 
 | Skill | When to use |
 | ----- | ----------- |

--- a/claude/.claude/docs/README.md
+++ b/claude/.claude/docs/README.md
@@ -8,7 +8,7 @@ Everything related to spec-driven (PRD-based) development lives in `prd-workflow
 
 | Document | Purpose | Consult When... |
 | --- | --- | --- |
-| [`prd-workflow/spec-driven-development.md`](prd-workflow/spec-driven-development.md) | Handbook: deviation tracking, checkpoints, document lifecycle, slash command map | Implementing against a PRD, handling a deviation, running a phase boundary sync |
+| [`prd-workflow/spec-driven-development.md`](prd-workflow/spec-driven-development.md) | Handbook: deviation tracking, checkpoints, document lifecycle, skill map | Implementing against a PRD, handling a deviation, running a phase boundary sync |
 | [`prd-workflow/prd-authoring-guide.md`](prd-workflow/prd-authoring-guide.md) | How to write a PRD through structured brainstorming | Starting a new project, planning a major feature area |
 | [`prd-workflow/templates/`](prd-workflow/templates/) | Starter files for new projects (`CLAUDE.md`, `docs/prd/` scaffolding) | Running `/bootstrap-prd` to scaffold a new project |
 
@@ -20,4 +20,4 @@ Everything related to spec-driven (PRD-based) development lives in `prd-workflow
 
 ## Skills
 
-Custom skills live in `~/.claude/skills/`. See the spec-driven development handbook (§7 "Slash Commands in the Development Cycle") for a full command map and lifecycle stage guidance.
+Custom skills live in `~/.claude/skills/`. See the spec-driven development handbook (§7 "Skills in the Development Cycle") for a full skill map and lifecycle stage guidance.

--- a/claude/.claude/docs/README.md
+++ b/claude/.claude/docs/README.md
@@ -18,6 +18,6 @@ Everything related to spec-driven (PRD-based) development lives in `prd-workflow
 | --- | --- | --- |
 | [`label-taxonomy.md`](label-taxonomy.md) | Unified vocabulary for commits, branches, issues, and project boards | Naming a branch, choosing a commit type, setting up GitHub labels |
 
-## Slash Commands
+## Skills
 
-Custom slash commands live in `~/.claude/commands/`. See the spec-driven development handbook (§7 "Slash Commands in the Development Cycle") for a full command map and lifecycle stage guidance.
+Custom skills live in `~/.claude/skills/`. See the spec-driven development handbook (§7 "Slash Commands in the Development Cycle") for a full command map and lifecycle stage guidance.

--- a/claude/.claude/docs/prd-workflow/spec-driven-development.md
+++ b/claude/.claude/docs/prd-workflow/spec-driven-development.md
@@ -276,7 +276,7 @@ This section maps every command to its place in the development cycle. Think of 
 | `/update-deps` | Update dependencies with testing between categories | Periodic maintenance |
 | `/readme-refresh` | Audit and update README, or bootstrap one | Periodic / phase boundary |
 
-> **Note:** `/simplify` is a built-in Claude Code skill, not a custom command in `~/.claude/commands/`. All other commands listed above are custom command definitions. When invoking `/simplify`, Claude Code loads it automatically as a skill — there is no `.md` file to maintain for it.
+> **Note:** `/simplify` is a built-in Claude Code skill. All other entries listed above are custom skills defined in `~/.claude/skills/`.
 
 ### The PR cycle (inner loop)
 

--- a/claude/.claude/docs/prd-workflow/spec-driven-development.md
+++ b/claude/.claude/docs/prd-workflow/spec-driven-development.md
@@ -4,7 +4,7 @@ A collaborative workflow for building software against a Product Requirements Do
 
 Informed by lessons learned building ComixDistro (13 phases, 380+ PRs, 18 PRD files).
 
-**Platform assumptions:** This workflow assumes GitHub as the hosting platform and the `gh` CLI for issue tracking, pull requests, and CI integration. The principles (modular specs, deviation tracking, checkpoint cadence) are platform-agnostic, but the slash commands and specific procedures rely on GitHub tooling. Adapting to GitLab, Bitbucket, or other platforms would require substituting the `gh`-based steps with equivalent tooling.
+**Platform assumptions:** This workflow assumes GitHub as the hosting platform and the `gh` CLI for issue tracking, pull requests, and CI integration. The principles (modular specs, deviation tracking, checkpoint cadence) are platform-agnostic, but the skills and specific procedures rely on GitHub tooling. Adapting to GitLab, Bitbucket, or other platforms would require substituting the `gh`-based steps with equivalent tooling.
 
 ---
 
@@ -195,7 +195,7 @@ The PRD is the primary driver. The ROADMAP is the work queue. Every implementati
 - ROADMAP checkboxes are the unit of work. One checkbox = one PR.
 - Deviation tracking is at its most rigorous — the spec is fresh and the system is being shaped.
 - The CHANGELOG is active. New entries appear regularly as implementation reveals things the spec didn't anticipate.
-- Slash commands like `/plan-phase`, `/resolve-issue`, and `/create-pr` drive the development cycle.
+- Skills like `/plan-phase`, `/resolve-issue`, and `/create-pr` drive the development cycle.
 
 **Risk:** Over-adherence. The spec is a plan, not a contract. If implementation reveals a better approach, update the spec — don't force the code into a shape that no longer makes sense.
 
@@ -249,15 +249,15 @@ The spec-driven approach isn't a phase you pass through — it's a habit you car
 
 ---
 
-## 7 Slash Commands in the Development Cycle
+## 7 Skills in the Development Cycle
 
-Slash commands are the operational backbone of spec-driven development. They encapsulate consistent, repeatable behavior at each stage of the workflow — reducing cognitive load, fighting fatigue, and ensuring steps aren't skipped.
+Skills are the operational backbone of spec-driven development. They encapsulate consistent, repeatable behavior at each stage of the workflow — reducing cognitive load, fighting fatigue, and ensuring steps aren't skipped.
 
-This section maps every command to its place in the development cycle. Think of it as the answer to: "What command do I run right now?"
+This section maps every skill to its place in the development cycle. Think of it as the answer to: "What skill do I run right now?"
 
-### The command library
+### The skill library
 
-| Command | Purpose | Cadence |
+| Skill | Purpose | Cadence |
 | ------- | ------- | ------- |
 | `/bootstrap-prd` | Scaffold PRD structure for a new project | Once per project |
 | `/plan-phase` | Create GitHub issues from a PRD phase | Once per phase |
@@ -314,7 +314,7 @@ Step 7 closes the loop. `/merge-pr` encapsulates the merge preferences (squash m
 
 At the start of each phase:
 
-1. **`/plan-phase`** — Read the relevant PRD files, create GitHub issues with acceptance criteria and implementation order. This is a planning-only command — no code is written.
+1. **`/plan-phase`** — Read the relevant PRD files, create GitHub issues with acceptance criteria and implementation order. This is a planning-only skill — no code is written.
 2. **`/setup-sprint`** *(optional)* — If the phase contains a batch of small, independent issues (common for chore or fix batches), create parallel worktrees. Each worktree gets its own branch and can be worked independently.
 
 ### Phase boundary
@@ -331,14 +331,14 @@ The `/debrief` is the natural place to surface drift that was missed during the 
 
 When you're disoriented, fatigued, or returning from a break:
 
-- **`/checkpoint`** — Reorient. Where am I in the ROADMAP? What's in flight? What are the next 2–3 items? This is the "where was I?" command.
+- **`/checkpoint`** — Reorient. Where am I in the ROADMAP? What's in flight? What are the next 2–3 items? This is the "where was I?" skill.
 - **Appendix A quick reference** — Scan the checklists to re-engage the workflow discipline.
 
 When you suspect drift has occurred:
 
 - **`/drift-check`** — Run it against the current branch to assess alignment. If drift is confirmed, follow the reactive workflow in §3b.
 
-### Project-level commands
+### Project-level skills
 
 These run infrequently but are important bookends:
 
@@ -348,9 +348,9 @@ These run infrequently but are important bookends:
 
 ### Lifecycle stage mapping
 
-Commands shift in importance as the project matures (see §6):
+Skills shift in importance as the project matures (see §6):
 
-| Command | Greenfield | MVP Complete | Mature |
+| Skill | Greenfield | MVP Complete | Mature |
 | ------- | ---------- | ------------ | ------ |
 | `/bootstrap-prd` | **Setup** | — | — |
 | `/plan-phase` | **Every phase** | Rare (new features only) | — |
@@ -369,11 +369,11 @@ Commands shift in importance as the project matures (see §6):
 | `/update-deps` | Periodic | Periodic | **Regular cadence** |
 | `/readme-refresh` | Bootstrap | **Full refresh** | Light periodic |
 
-Note how `/drift-check` intensity tracks project maturity: critical during greenfield when the spec is the primary reference, important during MVP transition, and lighter in the mature stage when living documents replace the PRD. The command still has value in the mature stage — it just checks against living docs (domain model, integration guides) rather than PRD files.
+Note how `/drift-check` intensity tracks project maturity: critical during greenfield when the spec is the primary reference, important during MVP transition, and lighter in the mature stage when living documents replace the PRD. The skill still has value in the mature stage — it just checks against living docs (domain model, integration guides) rather than PRD files.
 
-### The `/drift-check` command
+### The `/drift-check` skill
 
-The per-PR deviation check from §4 is supported by the `/drift-check` command.
+The per-PR deviation check from §4 is supported by the `/drift-check` skill.
 
 **When to run:** Before `/create-pr`, after implementation is complete. Also useful ad-hoc when you suspect drift.
 
@@ -390,7 +390,7 @@ The per-PR deviation check from §4 is supported by the `/drift-check` command.
 - Block the PR. It's advisory — a nudge, not a gate.
 - Replace human judgment. It surfaces signals; the developer interprets them.
 
-**Design principle:** Lightweight and fast. If running this command feels like a burden, it won't get used. Target: under 30 seconds for a typical PR.
+**Design principle:** Lightweight and fast. If running this skill feels like a burden, it won't get used. Target: under 30 seconds for a typical PR.
 
 ---
 

--- a/claude/.claude/skills/bootstrap-prd/SKILL.md
+++ b/claude/.claude/skills/bootstrap-prd/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: bootstrap-prd
+description: Set up PRD-driven development infrastructure for a new project, including directory structure, templates, and roadmap.
+disable-model-invocation: true
+---
+
 # Bootstrap PRD Command
 
 Set up PRD-driven development infrastructure for a new project. This command handles two workflows: **PRD-first** (PRD files already exist, scaffold the project around them) and **scaffold-first** (no PRD yet, create template files to be filled in). The command detects which situation applies and adapts.

--- a/claude/.claude/skills/bootstrap-prd/SKILL.md
+++ b/claude/.claude/skills/bootstrap-prd/SKILL.md
@@ -4,9 +4,9 @@ description: Set up PRD-driven development infrastructure for a new project, inc
 disable-model-invocation: true
 ---
 
-# Bootstrap PRD Command
+# Bootstrap PRD
 
-Set up PRD-driven development infrastructure for a new project. This command handles two workflows: **PRD-first** (PRD files already exist, scaffold the project around them) and **scaffold-first** (no PRD yet, create template files to be filled in). The command detects which situation applies and adapts.
+Set up PRD-driven development infrastructure for a new project. This skill handles two workflows: **PRD-first** (PRD files already exist, scaffold the project around them) and **scaffold-first** (no PRD yet, create template files to be filled in). The skill detects which situation applies and adapts.
 
 ## Your task
 
@@ -166,7 +166,7 @@ After approval, create each file:
 
 ## Important
 
-- **This command creates project files only.** It does not write application code or call any external APIs beyond `git` and `gh`.
+- **This skill creates project files only.** It does not write application code or call any external APIs beyond `git` and `gh`.
 - **Both checkpoints are hard stops.** Do not proceed without explicit approval.
 - **Shared docs are NOT copied.** `~/.claude/docs/label-taxonomy.md` remains a global reference — it should not be duplicated into individual projects.
 - **If a context window clear is needed**, it is safe to do so after Step 7 — the files exist on disk and will survive the clear.

--- a/claude/.claude/skills/checkpoint/SKILL.md
+++ b/claude/.claude/skills/checkpoint/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: checkpoint
+description: Quick 2-minute status update on current phase, completed work, blockers, and health check.
+disable-model-invocation: true
+---
+
 # Checkpoint Command
 
 You are a senior developer giving your executive a quick status update. This is the hallway conversation, not the sit-down meeting. Be concise, clear, and flag anything that needs attention.

--- a/claude/.claude/skills/checkpoint/SKILL.md
+++ b/claude/.claude/skills/checkpoint/SKILL.md
@@ -4,7 +4,7 @@ description: Quick 2-minute status update on current phase, completed work, bloc
 disable-model-invocation: true
 ---
 
-# Checkpoint Command
+# Checkpoint
 
 You are a senior developer giving your executive a quick status update. This is the hallway conversation, not the sit-down meeting. Be concise, clear, and flag anything that needs attention.
 

--- a/claude/.claude/skills/commit/SKILL.md
+++ b/claude/.claude/skills/commit/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: commit
+description: Stage and commit changes with intelligent Conventional Commits message generation and commit-splitting analysis.
+disable-model-invocation: true
+---
+
 # Commit Command
 
 Create git commits with intelligent message generation and commit-splitting analysis.

--- a/claude/.claude/skills/commit/SKILL.md
+++ b/claude/.claude/skills/commit/SKILL.md
@@ -4,7 +4,7 @@ description: Stage and commit changes with intelligent Conventional Commits mess
 disable-model-invocation: true
 ---
 
-# Commit Command
+# Commit
 
 Create git commits with intelligent message generation and commit-splitting analysis.
 

--- a/claude/.claude/skills/create-pr/SKILL.md
+++ b/claude/.claude/skills/create-pr/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: create-pr
+description: Create a pull request with auto-generated description, issue linking, and ROADMAP updates.
+disable-model-invocation: true
+argument-hint: "[base-branch]"
+---
+
 # Create Pull Request Command
 
 Create a pull request from the current branch with proper formatting and issue linking.

--- a/claude/.claude/skills/create-pr/SKILL.md
+++ b/claude/.claude/skills/create-pr/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 argument-hint: "[base-branch]"
 ---
 
-# Create Pull Request Command
+# Create Pull Request
 
 Create a pull request from the current branch with proper formatting and issue linking.
 

--- a/claude/.claude/skills/debrief/SKILL.md
+++ b/claude/.claude/skills/debrief/SKILL.md
@@ -4,7 +4,7 @@ description: Detailed technical walkthrough covering architecture, test coverage
 disable-model-invocation: true
 ---
 
-# Debrief Command
+# Debrief
 
 You are a senior developer presenting your recent work to a technically savvy executive who cares deeply about code quality, architecture decisions, and understanding the codebase. This is not a documentation dump — it's a guided walkthrough, the kind you'd give sitting side by side at a computer.
 

--- a/claude/.claude/skills/debrief/SKILL.md
+++ b/claude/.claude/skills/debrief/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: debrief
+description: Detailed technical walkthrough covering architecture, test coverage, product tour, and key design decisions.
+disable-model-invocation: true
+---
+
 # Debrief Command
 
 You are a senior developer presenting your recent work to a technically savvy executive who cares deeply about code quality, architecture decisions, and understanding the codebase. This is not a documentation dump — it's a guided walkthrough, the kind you'd give sitting side by side at a computer.

--- a/claude/.claude/skills/drift-check/SKILL.md
+++ b/claude/.claude/skills/drift-check/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: drift-check
+description: Pre-PR advisory check for deviations from the project spec. Read-only analysis.
+disable-model-invocation: true
+---
+
 # Drift Check Command
 
 Pre-PR deviation check against the project spec. Run this before `/create-pr` to verify alignment between implementation and documentation.

--- a/claude/.claude/skills/drift-check/SKILL.md
+++ b/claude/.claude/skills/drift-check/SKILL.md
@@ -4,11 +4,11 @@ description: Pre-PR advisory check for deviations from the project spec. Read-on
 disable-model-invocation: true
 ---
 
-# Drift Check Command
+# Drift Check
 
 Pre-PR deviation check against the project spec. Run this before `/create-pr` to verify alignment between implementation and documentation.
 
-> **Reference:** See `~/.claude/docs/prd-workflow/spec-driven-development.md` §2–§4 for the deviation threshold, workflow, and checkpoint cadence that this command operationalizes.
+> **Reference:** See `~/.claude/docs/prd-workflow/spec-driven-development.md` §2–§4 for the deviation threshold, workflow, and checkpoint cadence that this skill operationalizes.
 
 ## Your task
 

--- a/claude/.claude/skills/md2pdf/SKILL.md
+++ b/claude/.claude/skills/md2pdf/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 argument-hint: "[file.md]"
 ---
 
-# Markdown to PDF Command
+# Markdown to PDF
 
 Convert Markdown files to PDF with GitHub-style formatting using the `md2pdf` tool.
 

--- a/claude/.claude/skills/md2pdf/SKILL.md
+++ b/claude/.claude/skills/md2pdf/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: md2pdf
+description: Convert a Markdown file to PDF with GitHub-style formatting using the md2pdf tool.
+disable-model-invocation: true
+argument-hint: "[file.md]"
+---
+
 # Markdown to PDF Command
 
 Convert Markdown files to PDF with GitHub-style formatting using the `md2pdf` tool.

--- a/claude/.claude/skills/merge-pr/SKILL.md
+++ b/claude/.claude/skills/merge-pr/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 argument-hint: "[PR-number]"
 ---
 
-# Merge Pull Request Command
+# Merge Pull Request
 
 Merge a pull request with consistent practices: verify checks, squash merge, clean up the branch, and pull latest main.
 

--- a/claude/.claude/skills/merge-pr/SKILL.md
+++ b/claude/.claude/skills/merge-pr/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: merge-pr
+description: Merge a pull request with status checks, squash merge, and branch cleanup. Handles worktree contexts.
+disable-model-invocation: true
+argument-hint: "[PR-number]"
+---
+
 # Merge Pull Request Command
 
 Merge a pull request with consistent practices: verify checks, squash merge, clean up the branch, and pull latest main.

--- a/claude/.claude/skills/plan-phase/SKILL.md
+++ b/claude/.claude/skills/plan-phase/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: plan-phase
+description: Plan the next PRD phase by drafting issues, creating GitHub issues, and bridging planning to building.
+disable-model-invocation: true
+---
+
 # Plan Phase Command
 
 Plan the next phase of development from the PRD, create GitHub issues, and prepare for implementation. This command bridges planning and building — it creates the structure but writes no application code.

--- a/claude/.claude/skills/plan-phase/SKILL.md
+++ b/claude/.claude/skills/plan-phase/SKILL.md
@@ -4,9 +4,9 @@ description: Plan the next PRD phase by drafting issues, creating GitHub issues,
 disable-model-invocation: true
 ---
 
-# Plan Phase Command
+# Plan Phase
 
-Plan the next phase of development from the PRD, create GitHub issues, and prepare for implementation. This command bridges planning and building — it creates the structure but writes no application code.
+Plan the next phase of development from the PRD, create GitHub issues, and prepare for implementation. This skill bridges planning and building — it creates the structure but writes no application code.
 
 ## Your task
 
@@ -84,7 +84,7 @@ When the user is ready to begin, suggest the `/resolve-issue` command for the fi
 
 ## Important
 
-- **This command creates GitHub issues only.** It does not write application code, create branches, modify source files, or run tests.
+- **This skill creates GitHub issues only.** It does not write application code, create branches, modify source files, or run tests.
 - **Both checkpoints are hard stops.** Do not proceed without explicit approval.
 - **If a context window clear is needed**, it is safe to do so after Step 4 — the issues exist on GitHub and will survive the clear.
 - **Keep issues focused.** Each issue should be completable in a single PR. If an issue feels too large, split it.

--- a/claude/.claude/skills/qa-handoff/SKILL.md
+++ b/claude/.claude/skills/qa-handoff/SKILL.md
@@ -4,9 +4,9 @@ description: Generate a hands-on QA testing guide with walkthrough scenarios and
 disable-model-invocation: true
 ---
 
-# QA Handoff Command
+# QA Handoff
 
-**Applicability:** This command is designed for Rails applications that follow a PRD-driven development workflow with `docs/prd/ROADMAP.md` and a debriefs structure under `docs/debriefs/`. If the current project is not a Rails application or does not follow this structure, stop and tell the user this command is not applicable to the current project.
+**Applicability:** This command is designed for Rails applications that follow a PRD-driven development workflow with `docs/prd/ROADMAP.md` and a debriefs structure under `docs/debriefs/`. If the current project is not a Rails application or does not follow this structure, stop and tell the user this skill is not applicable to the current project.
 
 ---
 

--- a/claude/.claude/skills/qa-handoff/SKILL.md
+++ b/claude/.claude/skills/qa-handoff/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: qa-handoff
+description: Generate a hands-on QA testing guide with walkthrough scenarios and exploratory testing checklist.
+disable-model-invocation: true
+---
+
 # QA Handoff Command
 
 **Applicability:** This command is designed for Rails applications that follow a PRD-driven development workflow with `docs/prd/ROADMAP.md` and a debriefs structure under `docs/debriefs/`. If the current project is not a Rails application or does not follow this structure, stop and tell the user this command is not applicable to the current project.

--- a/claude/.claude/skills/readme-refresh/SKILL.md
+++ b/claude/.claude/skills/readme-refresh/SKILL.md
@@ -4,7 +4,7 @@ description: Audit and update a project README, or bootstrap a new one. Detects 
 disable-model-invocation: true
 ---
 
-# README Refresh Command
+# README Refresh
 
 Audit and update the project README, or bootstrap one if it doesn't exist. The README is a living document — it evolves with the code and should always reflect the current state of the project.
 
@@ -146,7 +146,7 @@ Write the file to `README.md` at the project root. Do **not** commit — let the
 
 ## Important
 
-- This command inspects and reports. It does not refactor code, change configuration, or install dependencies.
+- This skill inspects and reports. It does not refactor code, change configuration, or install dependencies.
 - Prose and subjective descriptions are the human's domain. The command handles mechanical, verifiable facts.
 - The command is framework-aware but not framework-specific. The scan in Step 1 covers Rails, Node, Python, Go, Rust, and Hugo projects. For unrecognized stacks, fall back to checking common files (`Makefile`, `Dockerfile`, `docker-compose.yml`, `README.md`).
 - When in doubt about whether something belongs in the README, include it in the findings report and let the user decide.

--- a/claude/.claude/skills/readme-refresh/SKILL.md
+++ b/claude/.claude/skills/readme-refresh/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: readme-refresh
+description: Audit and update a project README, or bootstrap a new one. Detects tech stack, versions, and services.
+disable-model-invocation: true
+---
+
 # README Refresh Command
 
 Audit and update the project README, or bootstrap one if it doesn't exist. The README is a living document — it evolves with the code and should always reflect the current state of the project.

--- a/claude/.claude/skills/resolve-issue/SKILL.md
+++ b/claude/.claude/skills/resolve-issue/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: resolve-issue
+description: Full issue workflow — fetch details, research, plan solution, implement, and verify.
+disable-model-invocation: true
+argument-hint: "[issue-number]"
+---
+
 # Resolve GitHub Issue Command
 
 Systematically resolve GitHub issues with a structured workflow.

--- a/claude/.claude/skills/resolve-issue/SKILL.md
+++ b/claude/.claude/skills/resolve-issue/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 argument-hint: "[issue-number]"
 ---
 
-# Resolve GitHub Issue Command
+# Resolve GitHub Issue
 
 Systematically resolve GitHub issues with a structured workflow.
 

--- a/claude/.claude/skills/review-pr/SKILL.md
+++ b/claude/.claude/skills/review-pr/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: review-pr
+description: Analyze and report on pull requests with configurable depth (quick, thorough, or security). Read-only.
+disable-model-invocation: true
+argument-hint: "[PR-number-or-URL]"
+---
+
 # Review Pull Request Command
 
 Review GitHub pull requests and report findings. This command analyzes and reports — it does not make changes or commit code.

--- a/claude/.claude/skills/review-pr/SKILL.md
+++ b/claude/.claude/skills/review-pr/SKILL.md
@@ -5,9 +5,9 @@ disable-model-invocation: true
 argument-hint: "[PR-number-or-URL]"
 ---
 
-# Review Pull Request Command
+# Review Pull Request
 
-Review GitHub pull requests and report findings. This command analyzes and reports — it does not make changes or commit code.
+Review GitHub pull requests and report findings. This skill analyzes and reports — it does not make changes or commit code.
 
 ## Command Options
 
@@ -69,4 +69,4 @@ Review GitHub pull requests and report findings. This command analyzes and repor
 6. **Recommend next steps**:
    - If clean: "This PR looks good to merge."
    - If fixes needed: Suggest using `/resolve-issue` or manual edits as appropriate.
-   - **Do NOT make changes, commit, or push.** This command is read-only.
+   - **Do NOT make changes, commit, or push.** This skill is read-only.

--- a/claude/.claude/skills/setup-sprint/SKILL.md
+++ b/claude/.claude/skills/setup-sprint/SKILL.md
@@ -4,9 +4,9 @@ description: Create parallel git worktrees for a batch of issues by label, with 
 disable-model-invocation: true
 ---
 
-# Setup Sprint Command
+# Setup Sprint
 
-Prepare parallel Git worktrees for a batch of issues filtered by label. This command sets up the workspace but does not start Claude Code instances or begin implementation.
+Prepare parallel Git worktrees for a batch of issues filtered by label. This skill sets up the workspace but does not start Claude Code instances or begin implementation.
 
 ## Your task
 
@@ -75,7 +75,7 @@ Then in each Claude Code session:
 
 ## Important
 
-- This command creates worktrees and copies permission files only. It does not start Claude Code instances, write application code, or begin implementation.
+- This skill creates worktrees and copies permission files only. It does not start Claude Code instances, write application code, or begin implementation.
 - The checkpoint in Step 2 is a hard stop. Do not create worktrees without user confirmation.
 - If `bundle install` or similar dependency setup is needed in each worktree, mention it in the report but do not run it.
 - The `$ARGUMENTS` value is typically a type label (e.g., `chore`, `fix`) but can be any GitHub issue label. The command filters by whatever label is provided.

--- a/claude/.claude/skills/setup-sprint/SKILL.md
+++ b/claude/.claude/skills/setup-sprint/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: setup-sprint
+description: Create parallel git worktrees for a batch of issues by label, with permissions and isolation.
+disable-model-invocation: true
+---
+
 # Setup Sprint Command
 
 Prepare parallel Git worktrees for a batch of issues filtered by label. This command sets up the workspace but does not start Claude Code instances or begin implementation.

--- a/claude/.claude/skills/sprint-issue/SKILL.md
+++ b/claude/.claude/skills/sprint-issue/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 argument-hint: "[issue-number]"
 ---
 
-# Sprint Issue Command
+# Sprint Issue
 
 Quickly resolve a small, well-scoped GitHub issue with a streamlined workflow. Use `/resolve-issue` for larger or more complex work that needs full checkpoints.
 
@@ -34,7 +34,7 @@ Quickly resolve a small, well-scoped GitHub issue with a streamlined workflow. U
 
 ## Important
 
-- This command is for small, well-scoped issues.
+- This skill is for small, well-scoped issues.
 - Skip the implementation plan checkpoint — move directly to implementation.
 - Still verify tests and linting before creating the PR.
 - **Commit messages**: Describe what the commit does, NO issue references.

--- a/claude/.claude/skills/sprint-issue/SKILL.md
+++ b/claude/.claude/skills/sprint-issue/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: sprint-issue
+description: Fast-track workflow for small, well-scoped issues. Skips the plan checkpoint for speed.
+disable-model-invocation: true
+argument-hint: "[issue-number]"
+---
+
 # Sprint Issue Command
 
 Quickly resolve a small, well-scoped GitHub issue with a streamlined workflow. Use `/resolve-issue` for larger or more complex work that needs full checkpoints.

--- a/claude/.claude/skills/update-deps/SKILL.md
+++ b/claude/.claude/skills/update-deps/SKILL.md
@@ -4,7 +4,7 @@ description: Update project dependencies incrementally with testing between cate
 disable-model-invocation: true
 ---
 
-# Update Dependencies Command
+# Update Dependencies
 
 Update project dependencies safely with testing between updates and documentation of breaking changes.
 

--- a/claude/.claude/skills/update-deps/SKILL.md
+++ b/claude/.claude/skills/update-deps/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: update-deps
+description: Update project dependencies incrementally with testing between categories. Framework-agnostic.
+disable-model-invocation: true
+---
+
 # Update Dependencies Command
 
 Update project dependencies safely with testing between updates and documentation of breaking changes.

--- a/setup.sh
+++ b/setup.sh
@@ -243,7 +243,7 @@ handle_stow_conflicts() {
     ".bashrc"
     ".claude/CLAUDE.md"
     ".claude/cheatsheet.md"
-    ".claude/commands"
+    ".claude/skills"
     ".claude/presets"
     ".claude/settings.json"
     ".claude/starship.toml"


### PR DESCRIPTION
## Summary

- Migrated all 16 slash commands from `.claude/commands/` to `.claude/skills/<name>/SKILL.md`
- Added YAML frontmatter to each skill: `disable-model-invocation: true`, `name`, `description`, and `argument-hint` where applicable
- Updated `setup.sh`, `cheatsheet.md`, `docs/README.md`, and `spec-driven-development.md` to reference the new skills directory
- Removed the old `commands/` directory

## Why

Skills are the recommended path forward for Claude Code custom commands. They're a superset — same `/name` invocation, plus support for frontmatter controls (`disable-model-invocation`, `argument-hint`), supporting files, subagent isolation, and scoped hooks. Commands and skills coexist, but skills take precedence when names collide.

## Test plan

- [x] All 16 skills created with correct frontmatter
- [x] `stow -n -v claude/` confirms `~/.claude/skills` symlink
- [x] Restowed claude package — old `commands` link removed, new `skills` link active
- [x] Shell linter passes
- [x] All 72 bats tests pass
- [x] Manually invoke a few skills (`/commit`, `/resolve-issue`) to verify runtime behavior