### PR TITLE
chore(claude): enable model invocation for read-only skills

### DIFF
--- a/claude/.claude/skills/checkpoint/SKILL.md
+++ b/claude/.claude/skills/checkpoint/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: checkpoint
 description: Quick 2-minute status update on current phase, completed work, blockers, and health check.
-disable-model-invocation: true
 ---
 
 # Checkpoint

--- a/claude/.claude/skills/debrief/SKILL.md
+++ b/claude/.claude/skills/debrief/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: debrief
 description: Detailed technical walkthrough covering architecture, test coverage, product tour, and key design decisions.
-disable-model-invocation: true
 ---
 
 # Debrief

--- a/claude/.claude/skills/drift-check/SKILL.md
+++ b/claude/.claude/skills/drift-check/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: drift-check
 description: Pre-PR advisory check for deviations from the project spec. Read-only analysis.
-disable-model-invocation: true
 ---
 
 # Drift Check

--- a/claude/.claude/skills/md2pdf/SKILL.md
+++ b/claude/.claude/skills/md2pdf/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: md2pdf
 description: Convert a Markdown file to PDF with GitHub-style formatting using the md2pdf tool.
-disable-model-invocation: true
 argument-hint: "[file.md]"
 ---
 

--- a/claude/.claude/skills/readme-refresh/SKILL.md
+++ b/claude/.claude/skills/readme-refresh/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: readme-refresh
 description: Audit and update a project README, or bootstrap a new one. Detects tech stack, versions, and services.
-disable-model-invocation: true
 ---
 
 # README Refresh


### PR DESCRIPTION
## Summary

- Remove `disable-model-invocation: true` from 5 read-only / low-stakes skills so Claude Code can auto-invoke them when context matches: `checkpoint`, `debrief`, `drift-check`, `md2pdf`, `readme-refresh`.
- Workflow-gate skills with side effects keep the flag: `commit`, `create-pr`, `merge-pr`, `update-deps`, `resolve-issue`, `setup-sprint`, `sprint-issue`, `plan-phase`, `bootstrap-prd`, `qa-handoff`.

## Why

PR #172 applied `disable-model-invocation: true` uniformly to all 16 migrated skills as a safe migration default. The practical effect was that Claude couldn't surface or run any of them proactively — even read-only ones with no downside.

The split now follows a clear principle: **side effects + rituals you drive** stay user-only; **read-only analysis + utilities** become model-invocable.

Per the official skills docs, `disable-model-invocation: true` removes the skill description from Claude's context entirely (so it has no awareness of the skill) and blocks auto-invocation. User invocation via `/skill-name` continues to work for every skill regardless of the flag.

## Test plan

- [ ] Verify the 5 skills appear in Claude Code's available-skills list when starting a session
- [ ] Type `/checkpoint` in a project to confirm explicit user invocation still works
- [ ] In a project, ask "where are we?" or similar to confirm Claude can now suggest or auto-fire `/checkpoint`
- [ ] Confirm none of the 10 retained-flag skills (e.g. `/commit`, `/create-pr`) fire automatically