### PR TITLE
feat(claude): render debrief full report as rich HTML

### DIFF
--- a/claude/.claude/skills/debrief/SKILL.md
+++ b/claude/.claude/skills/debrief/SKILL.md
@@ -17,7 +17,7 @@ When citing PRD sections, always use the format `filename.md §N "Section Headin
 
 Present a debrief covering the sections below. Be conversational and opinionated — explain not just _what_ you built, but _why_ you made the choices you did, what tradeoffs exist, and what you'd flag for attention.
 
-**Save both files under `docs/debriefs/`** so the executive can open them in their editor for easy navigation, scrolling, and copying. The full debrief and summary go in separate subdirectories as described in Section 5.
+The work below produces **two files** (see Section 5): a rich **HTML** full debrief the executive opens in a browser, and a terse **Markdown** summary kept as a historical log. Write the section content first, then render it into the HTML template.
 
 ---
 
@@ -84,21 +84,34 @@ Include at least one story per user role that's relevant to the new work. If the
 
 ### 5. Save Debrief Files
 
-Save two files with identical filenames in separate subdirectories:
+Save two files with the same date-and-slug stem in separate subdirectories — one HTML, one Markdown:
 
-**Full debrief** — the complete document covering Sections 1-4:
+**Full debrief (HTML)** — the complete document covering Sections 1-4, rendered as a rich, self-contained HTML page:
 
 ```text
-docs/debriefs/full/YYYY-MM-DD-[brief-topic].md
+docs/debriefs/full/YYYY-MM-DD-[brief-topic].html
 ```
 
-**Summary** — a concise historical record:
+**Summary (Markdown)** — a concise historical record:
 
 ```text
 docs/debriefs/summary/YYYY-MM-DD-[brief-topic].md
 ```
 
-The summary should contain:
+#### Rendering the full debrief into HTML
+
+The house style lives in `template.html` (in this skill's directory). Produce the full debrief by filling that template:
+
+1. **Read `template.html`** from this skill's directory and use it as the exact structure. Its head comment documents every token and section.
+2. **Inline the styles** — copy the template's `<style>` block verbatim into the output so the file is a single self-contained, portable `.html` (no external CSS, no build step). Do not link an external stylesheet.
+3. **Replace the `{{TOKENS}}`** (`{{PROJECT}}`, `{{TITLE}}`, `{{DATE}}`, `{{SCOPE}}`, `{{PRS}}`, `{{ISSUES}}`, `{{PRD_REFS}}`, and the section bodies `{{BUILT}}`, `{{ARCHITECTURE}}`, `{{TESTS}}`, `{{TOUR}}`). Drop metadata rows that don't apply.
+4. **Use the provided patterns:** Product Tour user stories become `<div class="story">` cards; the POODR spotlight and any flagged follow-ups become `<div class="callout">` blocks; architecture and data-flow structure becomes inline `<svg>` inside `<figure class="diagram">` — never ASCII art.
+5. **Keep the TOC in sync** with the sections you actually emit, and leave the high-value sections (What We Built, Product Tour) `open` by default.
+6. **No JavaScript.** The debrief is read-only; rely on native `<details>`/`<summary>` for collapsing.
+
+#### The summary file
+
+The Markdown summary should contain:
 
 - Project name, date, and scope (which PRD phase, which PRs/issues)
 - One-paragraph summary of what was built
@@ -106,18 +119,18 @@ The summary should contain:
 - Test coverage status (pass/fail, notable gaps)
 - Any items flagged for follow-up
 
-**Metadata formatting:** Both files begin with a metadata block (date, scope, PRs, issues, PRD references, etc.) immediately after the title. Format each metadata item as a **bulleted list** so that items render vertically in HTML instead of collapsing into a single paragraph.
+Begin it with a metadata block (date, scope, PRs, issues, PRD references) formatted as a bulleted list so items render vertically.
 
 Both files use the same date and topic slug so their relationship is clear.
 
-After saving, tell the executive where the files are and suggest opening the full debrief:
+After saving, tell the executive where the files are and suggest opening the full debrief in a browser:
 
 ```text
 Project:      MyApp
-Full debrief: docs/debriefs/full/2026-02-10-user-authentication.md
+Full debrief: docs/debriefs/full/2026-02-10-user-authentication.html
 Summary:      docs/debriefs/summary/2026-02-10-user-authentication.md
 
-Open the full debrief in your editor to walk through the user stories.
+Open the full debrief in your browser to walk through the user stories.
 ```
 
 ---

--- a/claude/.claude/skills/debrief/SKILL.md
+++ b/claude/.claude/skills/debrief/SKILL.md
@@ -106,8 +106,9 @@ The house style lives in `template.html` (in this skill's directory). Produce th
 2. **Inline the styles** — copy the template's `<style>` block verbatim into the output so the file is a single self-contained, portable `.html` (no external CSS, no build step). Do not link an external stylesheet.
 3. **Replace the `{{TOKENS}}`** (`{{PROJECT}}`, `{{TITLE}}`, `{{DATE}}`, `{{SCOPE}}`, `{{PRS}}`, `{{ISSUES}}`, `{{PRD_REFS}}`, and the section bodies `{{BUILT}}`, `{{ARCHITECTURE}}`, `{{TESTS}}`, `{{TOUR}}`). Drop metadata rows that don't apply.
 4. **Use the provided patterns:** Product Tour user stories become `<div class="story">` cards; the POODR spotlight and any flagged follow-ups become `<div class="callout">` blocks; architecture and data-flow structure becomes inline `<svg>` inside `<figure class="diagram">` — never ASCII art.
-5. **Keep the TOC in sync** with the sections you actually emit, and leave the high-value sections (What We Built, Product Tour) `open` by default.
-6. **No JavaScript.** The debrief is read-only; rely on native `<details>`/`<summary>` for collapsing.
+5. **Make pasteable values click-to-copy.** Anything the reader will type into the app — seed credentials, emails, and key URLs in the Product Tour — should be a `<button type="button" class="copy" data-copy="VALUE">VALUE</button>` control so it copies on click. This removes the single biggest walkthrough papercut.
+6. **Keep the TOC in sync** with the sections you actually emit, and leave the high-value sections (What We Built, Product Tour) `open` by default.
+7. **JavaScript is limited to the bundled click-to-copy helper** (the trailing `<script>` in the template). Keep it; add no other scripts, frameworks, or dependencies. Collapsing uses native `<details>`/`<summary>`.
 
 #### The summary file
 
@@ -123,14 +124,22 @@ Begin it with a metadata block (date, scope, PRs, issues, PRD references) format
 
 Both files use the same date and topic slug so their relationship is clear.
 
-After saving, tell the executive where the files are and suggest opening the full debrief in a browser:
+#### Open the debrief automatically
+
+After saving, **open the full debrief in the browser** so the executive doesn't have to — it is a single self-contained file, so this is instant and needs no server:
+
+```bash
+open docs/debriefs/full/YYYY-MM-DD-[brief-topic].html
+```
+
+`open` uses the system default browser. If the project needs a specific browser (e.g. for the Clipboard API), pin it: `open -a "Google Chrome" <file>`.
+
+Then tell the executive where both files are:
 
 ```text
 Project:      MyApp
-Full debrief: docs/debriefs/full/2026-02-10-user-authentication.html
+Full debrief: docs/debriefs/full/2026-02-10-user-authentication.html  (opened in your browser)
 Summary:      docs/debriefs/summary/2026-02-10-user-authentication.md
-
-Open the full debrief in your browser to walk through the user stories.
 ```
 
 ---

--- a/claude/.claude/skills/debrief/template.html
+++ b/claude/.claude/skills/debrief/template.html
@@ -9,13 +9,19 @@
   How to use:
   - Copy this whole document, then replace the {{TOKENS}} and the
     annotated <!-- SECTION --> regions with real content.
-  - Keep the <style> block verbatim unless intentionally evolving the
-    house style. Do NOT link an external stylesheet — inline only.
+  - Keep the <style> block and the trailing <script> verbatim unless
+    intentionally evolving the house style. Do NOT link external assets —
+    inline only, so each output is a single portable file.
   - Every major section is a <details> so the reader can collapse it.
     Leave the high-value sections (What We Built, Product Tour) open by
     default (the `open` attribute); collapse the rest.
   - Use inline <svg> for architecture / data-flow diagrams. Never ASCII art.
   - The table of contents is plain anchor links to each section's id.
+  - JavaScript is limited to the bundled click-to-copy helper — no
+    frameworks, no dependencies, no network. Make anything the reader will
+    paste (seed credentials, emails, URLs) a click-to-copy control:
+      <button type="button" class="copy" data-copy="admin@example.com">admin@example.com</button>
+    The value copied is data-copy (falling back to the element's text).
 -->
 <html lang="en">
 <head>
@@ -228,6 +234,27 @@
   .tag.good { color: var(--good); background: color-mix(in srgb, var(--good) 15%, var(--bg)); }
   .tag.warn { color: var(--warn); background: color-mix(in srgb, var(--warn) 15%, var(--bg)); }
   .tag.bad { color: var(--bad); background: color-mix(in srgb, var(--bad) 15%, var(--bg)); }
+  /* ---- Click-to-copy ---- */
+  .copy {
+    cursor: pointer;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: inherit;
+    font-family: var(--mono);
+    font-size: 0.85em;
+    padding: 0.1em 0.5em;
+    border-radius: 6px;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+    user-select: none;
+    vertical-align: baseline;
+    transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  }
+  .copy:hover { background: var(--accent-soft); border-color: var(--accent); }
+  .copy::after { content: "\29C9"; opacity: 0.55; font-size: 0.9em; }
+  .copy.copied { color: var(--good); border-color: var(--good); }
+  .copy.copied::after { content: "\2713"; opacity: 1; }
   footer.doc { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--border); color: var(--muted); font-size: 13px; }
   /* ---- Responsive ---- */
   @media (max-width: 800px) {
@@ -297,14 +324,18 @@
     <details class="section" id="tour" open>
       <summary>4 · Product Tour — Try It Yourself</summary>
       <div class="section-body">
-        <!-- One <div class="story"> per user story. Pattern:
+        <!-- One <div class="story"> per user story. Make credentials and URLs
+             click-to-copy so the reader can paste them without retyping. Pattern:
         <div class="story">
           <div class="story-head">Admin creates and approves a distributor
             <span class="role-pill">Admin</span></div>
           <div class="story-body">
             <ol>
-              <li>Visit <code>http://localhost:3000/...</code></li>
-              <li>Log in as <code>admin@example.com / password</code></li>
+              <li>Visit <button type="button" class="copy" data-copy="http://localhost:3000/admin/distributors">http://localhost:3000/admin/distributors</button></li>
+              <li>Log in as
+                <button type="button" class="copy" data-copy="admin@example.com">admin@example.com</button>
+                /
+                <button type="button" class="copy" data-copy="password">password</button></li>
               <li>Click "Distributors" in the nav.
                 <span class="expect">Expected: the table lists 3 seeded orgs.</span></li>
             </ol>
@@ -320,5 +351,39 @@
     </footer>
   </main>
 </div>
+<script>
+  // Click-to-copy. Any [data-copy] element copies its data-copy value
+  // (falling back to its text). Modern Clipboard API with a legacy
+  // execCommand fallback so it works on file:// and older browsers.
+  (function () {
+    function flash(el) {
+      el.classList.add("copied");
+      clearTimeout(el._copyTimer);
+      el._copyTimer = setTimeout(function () { el.classList.remove("copied"); }, 1200);
+    }
+    function legacyCopy(text, el) {
+      var ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "");
+      ta.style.position = "absolute";
+      ta.style.left = "-9999px";
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand("copy"); flash(el); } catch (e) {}
+      document.body.removeChild(ta);
+    }
+    document.addEventListener("click", function (e) {
+      var el = e.target.closest("[data-copy]");
+      if (!el) return;
+      var text = el.getAttribute("data-copy") || el.textContent.trim();
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(function () { flash(el); },
+          function () { legacyCopy(text, el); });
+      } else {
+        legacyCopy(text, el);
+      }
+    });
+  })();
+</script>
 </body>
 </html>

--- a/claude/.claude/skills/debrief/template.html
+++ b/claude/.claude/skills/debrief/template.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<!--
+  Debrief house-style template.
+
+  The /debrief skill INLINES this file's <style> block into each generated
+  debrief so the output is a single self-contained, portable .html file
+  (no external CSS, no build step, no JavaScript).
+
+  How to use:
+  - Copy this whole document, then replace the {{TOKENS}} and the
+    annotated <!-- SECTION --> regions with real content.
+  - Keep the <style> block verbatim unless intentionally evolving the
+    house style. Do NOT link an external stylesheet — inline only.
+  - Every major section is a <details> so the reader can collapse it.
+    Leave the high-value sections (What We Built, Product Tour) open by
+    default (the `open` attribute); collapse the rest.
+  - Use inline <svg> for architecture / data-flow diagrams. Never ASCII art.
+  - The table of contents is plain anchor links to each section's id.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{PROJECT}} — Debrief: {{TITLE}}</title>
+<style>
+  :root {
+    --bg: #ffffff;
+    --surface: #f6f8fa;
+    --surface-2: #eaeef2;
+    --border: #d0d7de;
+    --text: #1f2328;
+    --muted: #656d76;
+    --accent: #0969da;
+    --accent-soft: #ddf4ff;
+    --good: #1a7f37;
+    --warn: #9a6700;
+    --bad: #cf222e;
+    --code-bg: #f6f8fa;
+    --radius: 10px;
+    --maxw: 1080px;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --surface-2: #21262d;
+      --border: #30363d;
+      --text: #e6edf3;
+      --muted: #9198a1;
+      --accent: #4493f8;
+      --accent-soft: #121d2f;
+      --good: #3fb950;
+      --warn: #d29922;
+      --bad: #f85149;
+      --code-bg: #161b22;
+    }
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    line-height: 1.6;
+    font-size: 16px;
+  }
+  .wrap {
+    display: grid;
+    grid-template-columns: 240px minmax(0, 1fr);
+    gap: 40px;
+    max-width: var(--maxw);
+    margin: 0 auto;
+    padding: 32px 24px 96px;
+  }
+  /* ---- Table of contents ---- */
+  nav.toc {
+    position: sticky;
+    top: 24px;
+    align-self: start;
+    font-size: 14px;
+    max-height: calc(100vh - 48px);
+    overflow-y: auto;
+  }
+  nav.toc h2 {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+    margin: 0 0 12px;
+  }
+  nav.toc ol { list-style: none; margin: 0; padding: 0; }
+  nav.toc li { margin: 0 0 8px; }
+  nav.toc a {
+    color: var(--text);
+    text-decoration: none;
+    display: block;
+    padding: 4px 10px;
+    border-left: 2px solid transparent;
+    border-radius: 0 6px 6px 0;
+  }
+  nav.toc a:hover { background: var(--surface); border-left-color: var(--accent); color: var(--accent); }
+  /* ---- Main column ---- */
+  main { min-width: 0; }
+  header.doc {
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 24px;
+    margin-bottom: 8px;
+  }
+  .eyebrow {
+    color: var(--accent);
+    font-weight: 600;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 0 0 6px;
+  }
+  header.doc h1 { font-size: 30px; line-height: 1.2; margin: 0 0 16px; }
+  dl.meta {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 6px 16px;
+    margin: 0;
+    font-size: 14px;
+  }
+  dl.meta dt { color: var(--muted); font-weight: 600; }
+  dl.meta dd { margin: 0; }
+  /* ---- Sections ---- */
+  details.section {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin: 16px 0;
+    background: var(--bg);
+    overflow: hidden;
+  }
+  details.section > summary {
+    cursor: pointer;
+    padding: 16px 20px;
+    font-size: 19px;
+    font-weight: 600;
+    background: var(--surface);
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  details.section > summary::-webkit-details-marker { display: none; }
+  details.section > summary::before {
+    content: "›";
+    display: inline-block;
+    transition: transform 0.15s ease;
+    color: var(--muted);
+    font-size: 22px;
+    line-height: 1;
+  }
+  details.section[open] > summary::before { transform: rotate(90deg); }
+  .section-body { padding: 4px 20px 20px; }
+  h3 { font-size: 17px; margin: 24px 0 8px; }
+  h4 { font-size: 15px; margin: 18px 0 6px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  p { margin: 10px 0; }
+  a { color: var(--accent); }
+  code {
+    font-family: var(--mono);
+    font-size: 0.88em;
+    background: var(--surface-2);
+    padding: 0.15em 0.4em;
+    border-radius: 5px;
+  }
+  pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px 16px;
+    overflow-x: auto;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 14px; }
+  th, td { border: 1px solid var(--border); padding: 8px 12px; text-align: left; vertical-align: top; }
+  th { background: var(--surface); font-weight: 600; }
+  /* ---- Callouts ---- */
+  .callout {
+    border-left: 4px solid var(--accent);
+    background: var(--accent-soft);
+    border-radius: 0 var(--radius) var(--radius) 0;
+    padding: 12px 16px;
+    margin: 16px 0;
+  }
+  .callout.warn { border-left-color: var(--warn); background: color-mix(in srgb, var(--warn) 12%, var(--bg)); }
+  .callout.flag { border-left-color: var(--bad); background: color-mix(in srgb, var(--bad) 12%, var(--bg)); }
+  .callout .label { font-weight: 700; font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; display: block; margin-bottom: 4px; }
+  /* ---- Product tour story cards ---- */
+  .story {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin: 16px 0;
+    overflow: hidden;
+  }
+  .story > .story-head {
+    background: var(--surface);
+    padding: 12px 16px;
+    font-weight: 600;
+    border-bottom: 1px solid var(--border);
+  }
+  .story .role-pill {
+    display: inline-block;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--accent);
+    background: var(--accent-soft);
+    border-radius: 999px;
+    padding: 2px 10px;
+    margin-left: 8px;
+  }
+  .story ol { margin: 12px 0; padding-left: 28px; }
+  .story ol li { margin: 6px 0; }
+  .story .expect { color: var(--good); font-weight: 500; }
+  .story-body { padding: 4px 16px 14px; }
+  /* ---- Diagram figure ---- */
+  figure.diagram { margin: 18px 0; text-align: center; }
+  figure.diagram svg { max-width: 100%; height: auto; }
+  figure.diagram figcaption { color: var(--muted); font-size: 13px; margin-top: 8px; }
+  /* ---- Tags ---- */
+  .tag { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .tag.good { color: var(--good); background: color-mix(in srgb, var(--good) 15%, var(--bg)); }
+  .tag.warn { color: var(--warn); background: color-mix(in srgb, var(--warn) 15%, var(--bg)); }
+  .tag.bad { color: var(--bad); background: color-mix(in srgb, var(--bad) 15%, var(--bg)); }
+  footer.doc { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--border); color: var(--muted); font-size: 13px; }
+  /* ---- Responsive ---- */
+  @media (max-width: 800px) {
+    .wrap { grid-template-columns: 1fr; gap: 16px; padding: 20px 16px 64px; }
+    nav.toc { position: static; max-height: none; border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 16px; background: var(--surface); }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- TABLE OF CONTENTS: one <li><a> per section below. Keep ids in sync. -->
+  <nav class="toc">
+    <h2>Contents</h2>
+    <ol>
+      <li><a href="#built">What We Built</a></li>
+      <li><a href="#architecture">Architecture &amp; Decisions</a></li>
+      <li><a href="#tests">Test Coverage</a></li>
+      <li><a href="#tour">Product Tour</a></li>
+    </ol>
+  </nav>
+
+  <main>
+    <header class="doc">
+      <p class="eyebrow">{{PROJECT}} · Debrief</p>
+      <h1>{{TITLE}}</h1>
+      <!-- METADATA: date, scope, PRs, issues, PRD references. Drop rows that don't apply. -->
+      <dl class="meta">
+        <dt>Date</dt><dd>{{DATE}}</dd>
+        <dt>Scope</dt><dd>{{SCOPE}}</dd>
+        <dt>PRs</dt><dd>{{PRS}}</dd>
+        <dt>Issues</dt><dd>{{ISSUES}}</dd>
+        <dt>PRD refs</dt><dd>{{PRD_REFS}}</dd>
+      </dl>
+    </header>
+
+    <!-- SECTION 1 — open by default (highest value) -->
+    <details class="section" id="built" open>
+      <summary>1 · What We Built (and Why It Matters)</summary>
+      <div class="section-body">
+        <!-- Summary of features completed; connection to PRD phase; scope in/deferred. -->
+        {{BUILT}}
+      </div>
+    </details>
+
+    <!-- SECTION 2 — collapsed by default -->
+    <details class="section" id="architecture">
+      <summary>2 · Architecture &amp; Design Decisions</summary>
+      <div class="section-body">
+        <!-- Models/schema, patterns, frontend decisions, rejected alternatives.
+             Use <figure class="diagram"> with inline <svg> for structure/data-flow.
+             Use <div class="callout"> for POODR spotlight. -->
+        {{ARCHITECTURE}}
+      </div>
+    </details>
+
+    <!-- SECTION 3 — collapsed by default -->
+    <details class="section" id="tests">
+      <summary>3 · Test Coverage &amp; Quality</summary>
+      <div class="section-body">
+        <!-- Testing philosophy, what was/ wasn't tested, suite results, verify commands. -->
+        {{TESTS}}
+      </div>
+    </details>
+
+    <!-- SECTION 4 — open by default (most important per skill) -->
+    <details class="section" id="tour" open>
+      <summary>4 · Product Tour — Try It Yourself</summary>
+      <div class="section-body">
+        <!-- One <div class="story"> per user story. Pattern:
+        <div class="story">
+          <div class="story-head">Admin creates and approves a distributor
+            <span class="role-pill">Admin</span></div>
+          <div class="story-body">
+            <ol>
+              <li>Visit <code>http://localhost:3000/...</code></li>
+              <li>Log in as <code>admin@example.com / password</code></li>
+              <li>Click "Distributors" in the nav.
+                <span class="expect">Expected: the table lists 3 seeded orgs.</span></li>
+            </ol>
+          </div>
+        </div>
+        -->
+        {{TOUR}}
+      </div>
+    </details>
+
+    <footer class="doc">
+      Generated by the <code>/debrief</code> skill · {{DATE}}
+    </footer>
+  </main>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

First step of the incremental pivot to HTML output for human-consumed development artifacts: the `/debrief` skill now produces the **full debrief as a rich, self-contained HTML page** instead of Markdown. The terse summary stays Markdown — it's a machine-scannable log, not a read-it document.

The guiding principle: **HTML for artifacts humans consume; Markdown for artifacts agents maintain.**

## What changed

- **New `template.html`** — the debrief house style, inlined into each output so every file is a single portable artifact (no external assets, no build step):
  - Sticky table of contents, collapsible `<details>` sections, product-tour story cards, severity tags, and callouts.
  - **Inline-SVG diagrams** for architecture / data flow (replacing ASCII art).
  - **Click-to-copy** controls (vanilla JS, Clipboard API + `execCommand` fallback so it works on `file://`) for seed credentials, emails, and URLs — killing the copy-paste papercut during a product tour.
  - Light/dark via `prefers-color-scheme`, mobile responsive.
- **`SKILL.md`** — full debrief renders into the template at `docs/debriefs/full/*.html`; summary stays at `docs/debriefs/summary/*.md`. After saving, the skill **auto-opens** the file (`open <file>`) so it lands in the browser instantly — no server, no MCP.

## Verification

Filled the template with a realistic sample and confirmed in a browser: TOC nav, collapse/expand, callouts, styled code, story cards, and an inline-SVG state-machine diagram all render correctly. Clicked a credential control and read the clipboard back programmatically — it contained the expected value, confirming click-to-copy works.

## Notes

- **This PR is local-only by nature.** Debriefs are for the developer, not testers — the HTML opens locally via `open` and is never published anywhere. So the tester-facing publishing design (below) does not affect this PR.
- `/walkthrough` deliberately keeps its **PR-comment** output in Markdown (GitHub strips HTML/CSS/JS from comments).
- Rich HTML for **tester-facing** skills (`/walkthrough`, `/qa-handoff`) is follow-up work and will be **per-project opt-in: local by default, never assuming a remote target.** A project publishes to a GitHub Pages host only when its own `CLAUDE.md` declares one (repo + subfolder); with no declaration the skill stays fully local and `--publish` posts only the Markdown fallback rather than guessing a repo. This keeps solo/personal projects entirely local while nonprofit projects can opt in. `euroteamoutreach/qa-walkthroughs` is the first configured target, not a hardcoded default.
- The template lives with the debrief skill for now; it'll be promoted to a shared location once `/qa-handoff` reuses it.

## Test plan

- [ ] Run `/debrief` on a real project and confirm the HTML opens and reads well
- [ ] Click-to-copy works when opened via `file://` (the `open` path), exercising the `execCommand` fallback
- [ ] Summary still generated as Markdown in `docs/debriefs/summary/`
