### PR TITLE
feat(tmux): source optional local override file

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ Local customizations should be placed in `*.local` files:
 
 - `~/.gitconfig.local` - Personal git configuration
 - `~/.laptop.local` - Additional laptop setup customizations
+- `~/.config/tmux/tmux.conf.local` - Personal tmux overrides (extra plugins, key bindings, options)
 
 ## License
 

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -119,6 +119,10 @@ set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'tmux-plugins/tmux-urlview'
 
+# Source local overrides if present – useful for personal customizations
+# (additional plugins, key bindings, etc.) without modifying this file.
+source-file -q ~/.config/tmux/tmux.conf.local
+
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.config/tmux/plugins/tpm/tpm'
 


### PR DESCRIPTION
Closes #177

## What
Adds one line to `tmux/.config/tmux/tmux.conf`, just before the TPM init line:

    source-file -q ~/.config/tmux/tmux.conf.local

## Why
See #177 — enables layering personal tmux overrides without editing the
tracked config, mirroring the `.gitconfig.local` / `.laptop.local` pattern.
The `-q` flag makes it a no-op when the file is absent.

## Testing
- No local file present: tmux starts normally, no errors.
- With `~/.config/tmux/tmux.conf.local` present: its settings and plugins load.