### PR TITLE
feat(claude): publish HTML walkthroughs and QA handoffs to per-project hosts

### DIFF
--- a/claude/.claude/docs/prd-workflow/spec-driven-development.md
+++ b/claude/.claude/docs/prd-workflow/spec-driven-development.md
@@ -180,6 +180,15 @@ On ComixDistro, the data model started as PRD file `02-data-model.md` (planning)
 
 Documents that have served their purpose but contain valuable historical context should be archived, not deleted. An `archives/` directory within `docs/` keeps them accessible without cluttering the working document set. Good candidates: research documents, one-time audit reports, brainstorming artifacts, and reading guides for completed reviews.
 
+### Medium: HTML vs. Markdown
+
+Document medium follows the same lifecycle split. Markdown for what an agent edits or an archive preserves; HTML for what a human reads once and moves on.
+
+- **Markdown:** PRD files, ROADMAP, CHANGELOG, this handbook, skill instructions (SKILL.md), debrief summaries. Diffable, machine-readable, single source of truth.
+- **HTML:** debrief full reports, walkthroughs, QA handoffs, plans, mockups. Self-contained single files with click-to-copy controls, interactive checklists, and inline SVG. Opened in a browser with `open` — no build, no server.
+
+The skills that produce HTML artifacts share a house style (`~/.claude/skills/_shared/house-style.html`) and a publish pipeline (see §7 "Publishing artifacts to remote testers") so the output is consistent and portable. The format that is easiest to maintain is not always the format that is most useful to read; the split keeps both honest.
+
 ---
 
 ## 6 PRD Lifecycle — From Greenfield to Mature
@@ -268,10 +277,10 @@ This section maps every skill to its place in the development cycle. Think of it
 | `/simplify` | Review changed code for reuse, quality, efficiency | Pre-PR |
 | `/drift-check` | Deviation check against the spec | Pre-PR |
 | `/create-pr` | Create PR with issue linking and ROADMAP update | Per issue |
-| `/walkthrough` | Generate a browser walkthrough of user-facing changes; `--publish` posts it to the PR for QA | Pre-review, then pre-merge (user-facing PRs) |
+| `/walkthrough` | Generate a browser walkthrough of user-facing changes; `--publish` renders HTML, uploads to the project's QA host (when configured), and posts a PR comment with the link | Pre-review, then pre-merge (user-facing PRs) |
 | `/review-pr` | Analyze a PR for quality issues | Pre-merge |
 | `/merge-pr` | Squash merge, clean up branch, pull latest main | Post-review |
-| `/qa-handoff` | Generate a hands-on QA testing guide | Per feature (when needed) |
+| `/qa-handoff` | Generate a hands-on QA testing guide as a self-contained HTML page; `--publish` uploads it to the project's QA host | Per feature (when needed) |
 | `/checkpoint` | Quick status check: where am I, what's next | Ad-hoc / returning from break |
 | `/debrief` | Detailed walkthrough of completed work | Phase boundary |
 | `/update-deps` | Update dependencies with testing between categories | Periodic maintenance |
@@ -307,7 +316,7 @@ This is where most development time is spent. One pass through this cycle produc
    └─ /review-pr               (quality, security, correctness)
 
 8. Publish walkthrough
-   └─ /walkthrough --publish   (final walkthrough → PR comment for QA — user-facing PRs)
+   └─ /walkthrough --publish   (renders HTML, uploads to project's QA host, posts PR comment with link)
 
 9. Merge
    └─ /merge-pr                (squash merge, clean up, pull main)
@@ -315,7 +324,7 @@ This is where most development time is spent. One pass through this cycle produc
 
 Steps 3 and 4 are the pre-PR quality gates. `/simplify` looks at the code itself; `/drift-check` looks at the code's relationship to the spec. Together they catch both implementation quality issues and specification drift before the PR is created.
 
-Steps 6 and 8 are the walkthrough's two slots, both conditional on the PR having user-facing changes. At step 6, `/walkthrough` produces a throwaway browser checklist so the orchestrator can exercise the feature before spending review attention on the code; it is re-run as fixes land. At step 8, once the code is final, `/walkthrough --publish` posts that walkthrough as a PR comment so the QA tester can follow it after deploy. For PRs with no user-facing surface the skill reports that and exits at either slot.
+Steps 6 and 8 are the walkthrough's two slots, both conditional on the PR having user-facing changes. At step 6, `/walkthrough` produces a throwaway browser checklist (Markdown, in `tmp/`) so the orchestrator can exercise the feature before spending review attention on the code; it is re-run as fixes land. At step 8, once the code is final, `/walkthrough --publish` renders a rich HTML version, uploads it to the project's QA host (when one is declared — see "Publishing artifacts to remote testers" below), and posts a PR comment linking to it so the QA tester can follow it after deploy. For PRs with no user-facing surface the skill reports that and exits at either slot.
 
 Step 9 closes the loop. `/merge-pr` encapsulates the merge preferences (squash merge by default), cleans up the feature branch, and pulls the latest main — ensuring a consistent end state after every PR.
 
@@ -379,6 +388,21 @@ Skills shift in importance as the project matures (see §6):
 | `/readme-refresh` | Bootstrap | **Full refresh** | Light periodic |
 
 Note how `/drift-check` intensity tracks project maturity: critical during greenfield when the spec is the primary reference, important during MVP transition, and lighter in the mature stage when living documents replace the PRD. The skill still has value in the mature stage — it just checks against living docs (domain model, integration guides) rather than PRD files.
+
+### Publishing artifacts to remote testers
+
+`/walkthrough` and `/qa-handoff` produce HTML artifacts. A remote tester who is not cloning the repo needs a hosted copy. Publishing is per-project opt-in, declared in the project's own `CLAUDE.md`: a `## QA Publish Target` heading followed by a `yaml` fenced code block containing `repo: <owner>/<pages-repo>` and `subfolder: <project-slug>`. See the bootstrap template at `~/.claude/docs/prd-workflow/templates/CLAUDE.md` for the exact block.
+
+The repo must have GitHub Pages enabled; the live URL is derived as `https://<owner>.github.io/<pages-repo>/<subfolder>/<file>.html`.
+
+The shared pipeline at `~/.claude/skills/_shared/publish-artifact.sh` reads that block, uploads the HTML via the GitHub Contents API (create or update via SHA), and — when given `--pr <N>` — posts a PR comment with the live link.
+
+If the block is absent or contains placeholder values, the pipeline never guesses a target:
+
+- **`/walkthrough --publish`** falls back to posting the Markdown twin alone as the PR comment (the pre-HTML behaviour).
+- **`/qa-handoff --publish`** stays local and prints a warning.
+
+Solo projects (a blog, a one-off prototype) simply omit the block.
 
 ### The `/drift-check` skill
 

--- a/claude/.claude/docs/prd-workflow/spec-driven-development.md
+++ b/claude/.claude/docs/prd-workflow/spec-driven-development.md
@@ -393,7 +393,7 @@ Note how `/drift-check` intensity tracks project maturity: critical during green
 
 `/walkthrough` and `/qa-handoff` produce HTML artifacts. A remote tester who is not cloning the repo needs a hosted copy. Publishing is per-project opt-in, declared in the project's own `CLAUDE.md`: a `## QA Publish Target` heading followed by a `yaml` fenced code block containing `repo: <owner>/<pages-repo>` and `subfolder: <project-slug>`. See the bootstrap template at `~/.claude/docs/prd-workflow/templates/CLAUDE.md` for the exact block.
 
-The repo must have GitHub Pages enabled; the live URL is derived as `https://<owner>.github.io/<pages-repo>/<subfolder>/<file>.html`.
+The repo must have GitHub Pages enabled and served from the **default branch** (the Contents API writes there); the live URL is derived as `https://<owner>.github.io/<pages-repo>/<subfolder>/<file>.html`. A user/org-pages repo (named `<owner>.github.io`) is served at the apex with no repo segment — the pipeline detects that and emits the correct URL with a warning so the configuration is visible.
 
 The shared pipeline at `~/.claude/skills/_shared/publish-artifact.sh` reads that block, uploads the HTML via the GitHub Contents API (create or update via SHA), and — when given `--pr <N>` — posts a PR comment with the live link.
 

--- a/claude/.claude/docs/prd-workflow/templates/CLAUDE.md
+++ b/claude/.claude/docs/prd-workflow/templates/CLAUDE.md
@@ -45,3 +45,26 @@ bin/standardrb --fix       # Lint and auto-fix
 - **Linting:** <!-- TODO: linter name -->, zero warnings, run before every commit
 - **PRD deviations:** Log in `docs/prd/CHANGELOG.md` before merging — never silently deviate
 - **Testing:** <!-- TODO: framework -->, AAA pattern, <!-- TODO: test runner command -->
+
+## QA Publish Target
+
+<!--
+  Opt-in: tester-facing HTML from `/walkthrough` and `/qa-handoff` will be
+  published to the repo + subfolder declared below, and a live GitHub Pages
+  link will be posted as the PR comment.
+
+  Delete this entire section to keep tester artifacts local-only. With no
+  declaration, `--publish` falls back to a Markdown PR comment and never
+  guesses a remote target.
+
+  Required fields:
+    - repo:      <owner>/<repo>  — must have GitHub Pages enabled
+    - subfolder: <slug>          — path under the repo; isolates this project
+
+  Live URL is derived: https://<owner>.github.io/<repo>/<subfolder>/<file>.html
+-->
+
+```yaml
+repo: <owner>/<repo>
+subfolder: <project-slug>
+```

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -157,7 +157,8 @@
     "lua-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "starship-claude@starship-claude": true,
-    "ruby-lsp@claude-plugins-official": true
+    "ruby-lsp@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "obsidian-skills": {
@@ -173,6 +174,6 @@
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",
   "editorMode": "vim",
-  "voiceEnabled": true,
-  "agentPushNotifEnabled": true
+  "agentPushNotifEnabled": true,
+  "voiceEnabled": true
 }

--- a/claude/.claude/skills/_shared/house-style.html
+++ b/claude/.claude/skills/_shared/house-style.html
@@ -30,7 +30,16 @@
   - Copy:       button.copy[data-copy="VALUE"] — click-to-copy control; copies
                 data-copy (falling back to text). Use for anything the reader
                 will paste (credentials, emails, URLs).
+  - Forms:      .field (label + input/textarea), input[type=text], textarea,
+                .btn (primary button), .actions (button row), .form-status
+                (green confirmation text). For interactive artifacts.
+  - Checklist:  ul.checklist > li > label > input[type=checkbox] — interactive
+                checkboxes the reader can tick.
   - Footer:     footer.doc.
+
+  The click-to-copy <script> below is the ONLY shared script. A skill that
+  needs richer interactivity (e.g. a feedback form that exports Markdown) adds
+  its own small vanilla <script> in its own template — not here.
 -->
 <style>
   :root {
@@ -259,6 +268,40 @@
   .copy::after { content: "\29C9"; opacity: 0.55; font-size: 0.9em; }
   .copy.copied { color: var(--good); border-color: var(--good); }
   .copy.copied::after { content: "\2713"; opacity: 1; }
+  /* ---- Forms ---- */
+  .field { margin: 14px 0; }
+  .field label { display: block; font-weight: 600; font-size: 14px; margin-bottom: 6px; }
+  input[type="text"], textarea {
+    width: 100%;
+    font-family: var(--sans);
+    font-size: 14px;
+    color: var(--text);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 8px 10px;
+  }
+  textarea { min-height: 72px; resize: vertical; line-height: 1.5; }
+  input[type="text"]:focus, textarea:focus { outline: none; border-color: var(--accent); }
+  .btn {
+    cursor: pointer;
+    font-family: var(--sans);
+    font-size: 14px;
+    font-weight: 600;
+    color: #ffffff;
+    background: var(--accent);
+    border: 1px solid var(--accent);
+    border-radius: 8px;
+    padding: 8px 16px;
+  }
+  .btn:hover { filter: brightness(1.08); }
+  .actions { display: flex; align-items: center; gap: 12px; margin-top: 12px; flex-wrap: wrap; }
+  .form-status { color: var(--good); font-size: 13px; font-weight: 500; }
+  /* ---- Checklist ---- */
+  ul.checklist { list-style: none; margin: 12px 0; padding: 0; }
+  ul.checklist li { margin: 8px 0; }
+  ul.checklist label { display: flex; gap: 8px; align-items: flex-start; cursor: pointer; }
+  ul.checklist input { margin-top: 5px; flex: none; }
   footer.doc { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--border); color: var(--muted); font-size: 13px; }
   /* ---- Responsive ---- */
   @media (max-width: 800px) {

--- a/claude/.claude/skills/_shared/house-style.html
+++ b/claude/.claude/skills/_shared/house-style.html
@@ -30,16 +30,14 @@
   - Copy:       button.copy[data-copy="VALUE"] — click-to-copy control; copies
                 data-copy (falling back to text). Use for anything the reader
                 will paste (credentials, emails, URLs).
-  - Forms:      .field (label + input/textarea), input[type=text], textarea,
-                .btn (primary button), .actions (button row), .form-status
-                (green confirmation text). For interactive artifacts.
+  - Button:     .btn — primary CTA. Works on both <button> and <a>.
   - Checklist:  ul.checklist > li > label > input[type=checkbox] — interactive
                 checkboxes the reader can tick.
   - Footer:     footer.doc.
 
   The click-to-copy <script> below is the ONLY shared script. A skill that
-  needs richer interactivity (e.g. a feedback form that exports Markdown) adds
-  its own small vanilla <script> in its own template — not here.
+  needs richer interactivity adds its own small vanilla <script> in its own
+  template — not here.
 -->
 <style>
   :root {
@@ -268,22 +266,9 @@
   .copy::after { content: "\29C9"; opacity: 0.55; font-size: 0.9em; }
   .copy.copied { color: var(--good); border-color: var(--good); }
   .copy.copied::after { content: "\2713"; opacity: 1; }
-  /* ---- Forms ---- */
-  .field { margin: 14px 0; }
-  .field label { display: block; font-weight: 600; font-size: 14px; margin-bottom: 6px; }
-  input[type="text"], textarea {
-    width: 100%;
-    font-family: var(--sans);
-    font-size: 14px;
-    color: var(--text);
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 8px 10px;
-  }
-  textarea { min-height: 72px; resize: vertical; line-height: 1.5; }
-  input[type="text"]:focus, textarea:focus { outline: none; border-color: var(--accent); }
+  /* ---- Button (primary CTA; works on <button> or <a>) ---- */
   .btn {
+    display: inline-block;
     cursor: pointer;
     font-family: var(--sans);
     font-size: 14px;
@@ -293,10 +278,9 @@
     border: 1px solid var(--accent);
     border-radius: 8px;
     padding: 8px 16px;
+    text-decoration: none;
   }
   .btn:hover { filter: brightness(1.08); }
-  .actions { display: flex; align-items: center; gap: 12px; margin-top: 12px; flex-wrap: wrap; }
-  .form-status { color: var(--good); font-size: 13px; font-weight: 500; }
   /* ---- Checklist ---- */
   ul.checklist { list-style: none; margin: 12px 0; padding: 0; }
   ul.checklist li { margin: 8px 0; }

--- a/claude/.claude/skills/_shared/house-style.html
+++ b/claude/.claude/skills/_shared/house-style.html
@@ -1,0 +1,302 @@
+<!--
+  Shared house style for HTML artifacts.
+
+  This is NOT a skill (no SKILL.md) and not a standalone page. It is the single
+  source of the visual look + click-to-copy behavior shared by the artifact
+  skills (/debrief, /qa-handoff, /walkthrough).
+
+  How skills use it:
+  - Inline the <style> block below into the output's <head>.
+  - Inline the <script> block below just before the output's </body>.
+  - Each skill supplies its own document BODY structure; this file only
+    supplies the look and the copy helper. Keep both blocks verbatim so every
+    artifact stays a single self-contained, portable file (no external assets,
+    no build step).
+  - When a skill needs a genuinely new component, add its CSS here so the look
+    stays consistent across artifacts — do not fork per-skill styles.
+
+  Component vocabulary (classes available to every artifact):
+  - Layout:     .wrap (240px sidebar + content grid), nav.toc (sticky TOC),
+                main, header.doc, .eyebrow, h1, dl.meta (metadata grid).
+  - Sections:   details.section > summary  (collapsible card; add `open` to
+                expand by default), .section-body.
+  - Prose:      h3, h4, p, a, code, pre, table/th/td.
+  - Callouts:   .callout (info, default), .callout.warn, .callout.flag (alert);
+                put a .label inside for the heading.
+  - Stories:    .story > .story-head (+ .role-pill), .story-body,
+                .story .expect (green "expected result" text).
+  - Diagrams:   figure.diagram > svg + figcaption (inline SVG; never ASCII art).
+  - Tags:       .tag.good / .tag.warn / .tag.bad (small status pills).
+  - Copy:       button.copy[data-copy="VALUE"] — click-to-copy control; copies
+                data-copy (falling back to text). Use for anything the reader
+                will paste (credentials, emails, URLs).
+  - Footer:     footer.doc.
+-->
+<style>
+  :root {
+    --bg: #ffffff;
+    --surface: #f6f8fa;
+    --surface-2: #eaeef2;
+    --border: #d0d7de;
+    --text: #1f2328;
+    --muted: #656d76;
+    --accent: #0969da;
+    --accent-soft: #ddf4ff;
+    --good: #1a7f37;
+    --warn: #9a6700;
+    --bad: #cf222e;
+    --code-bg: #f6f8fa;
+    --radius: 10px;
+    --maxw: 1080px;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --surface-2: #21262d;
+      --border: #30363d;
+      --text: #e6edf3;
+      --muted: #9198a1;
+      --accent: #4493f8;
+      --accent-soft: #121d2f;
+      --good: #3fb950;
+      --warn: #d29922;
+      --bad: #f85149;
+      --code-bg: #161b22;
+    }
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    line-height: 1.6;
+    font-size: 16px;
+  }
+  .wrap {
+    display: grid;
+    grid-template-columns: 240px minmax(0, 1fr);
+    gap: 40px;
+    max-width: var(--maxw);
+    margin: 0 auto;
+    padding: 32px 24px 96px;
+  }
+  /* ---- Table of contents ---- */
+  nav.toc {
+    position: sticky;
+    top: 24px;
+    align-self: start;
+    font-size: 14px;
+    max-height: calc(100vh - 48px);
+    overflow-y: auto;
+  }
+  nav.toc h2 {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+    margin: 0 0 12px;
+  }
+  nav.toc ol { list-style: none; margin: 0; padding: 0; }
+  nav.toc li { margin: 0 0 8px; }
+  nav.toc a {
+    color: var(--text);
+    text-decoration: none;
+    display: block;
+    padding: 4px 10px;
+    border-left: 2px solid transparent;
+    border-radius: 0 6px 6px 0;
+  }
+  nav.toc a:hover { background: var(--surface); border-left-color: var(--accent); color: var(--accent); }
+  /* ---- Main column ---- */
+  main { min-width: 0; }
+  header.doc {
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 24px;
+    margin-bottom: 8px;
+  }
+  .eyebrow {
+    color: var(--accent);
+    font-weight: 600;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 0 0 6px;
+  }
+  header.doc h1 { font-size: 30px; line-height: 1.2; margin: 0 0 16px; }
+  dl.meta {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 6px 16px;
+    margin: 0;
+    font-size: 14px;
+  }
+  dl.meta dt { color: var(--muted); font-weight: 600; }
+  dl.meta dd { margin: 0; }
+  /* ---- Sections ---- */
+  details.section {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin: 16px 0;
+    background: var(--bg);
+    overflow: hidden;
+  }
+  details.section > summary {
+    cursor: pointer;
+    padding: 16px 20px;
+    font-size: 19px;
+    font-weight: 600;
+    background: var(--surface);
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  details.section > summary::-webkit-details-marker { display: none; }
+  details.section > summary::before {
+    content: "›";
+    display: inline-block;
+    transition: transform 0.15s ease;
+    color: var(--muted);
+    font-size: 22px;
+    line-height: 1;
+  }
+  details.section[open] > summary::before { transform: rotate(90deg); }
+  .section-body { padding: 4px 20px 20px; }
+  h3 { font-size: 17px; margin: 24px 0 8px; }
+  h4 { font-size: 15px; margin: 18px 0 6px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+  p { margin: 10px 0; }
+  a { color: var(--accent); }
+  code {
+    font-family: var(--mono);
+    font-size: 0.88em;
+    background: var(--surface-2);
+    padding: 0.15em 0.4em;
+    border-radius: 5px;
+  }
+  pre {
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px 16px;
+    overflow-x: auto;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  pre code { background: none; padding: 0; font-size: inherit; }
+  table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 14px; }
+  th, td { border: 1px solid var(--border); padding: 8px 12px; text-align: left; vertical-align: top; }
+  th { background: var(--surface); font-weight: 600; }
+  /* ---- Callouts ---- */
+  .callout {
+    border-left: 4px solid var(--accent);
+    background: var(--accent-soft);
+    border-radius: 0 var(--radius) var(--radius) 0;
+    padding: 12px 16px;
+    margin: 16px 0;
+  }
+  .callout.warn { border-left-color: var(--warn); background: color-mix(in srgb, var(--warn) 12%, var(--bg)); }
+  .callout.flag { border-left-color: var(--bad); background: color-mix(in srgb, var(--bad) 12%, var(--bg)); }
+  .callout .label { font-weight: 700; font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; display: block; margin-bottom: 4px; }
+  /* ---- Story / step cards ---- */
+  .story {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin: 16px 0;
+    overflow: hidden;
+  }
+  .story > .story-head {
+    background: var(--surface);
+    padding: 12px 16px;
+    font-weight: 600;
+    border-bottom: 1px solid var(--border);
+  }
+  .story .role-pill {
+    display: inline-block;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--accent);
+    background: var(--accent-soft);
+    border-radius: 999px;
+    padding: 2px 10px;
+    margin-left: 8px;
+  }
+  .story ol { margin: 12px 0; padding-left: 28px; }
+  .story ol li { margin: 6px 0; }
+  .story .expect { color: var(--good); font-weight: 500; }
+  .story-body { padding: 4px 16px 14px; }
+  /* ---- Diagram figure ---- */
+  figure.diagram { margin: 18px 0; text-align: center; }
+  figure.diagram svg { max-width: 100%; height: auto; }
+  figure.diagram figcaption { color: var(--muted); font-size: 13px; margin-top: 8px; }
+  /* ---- Tags ---- */
+  .tag { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .tag.good { color: var(--good); background: color-mix(in srgb, var(--good) 15%, var(--bg)); }
+  .tag.warn { color: var(--warn); background: color-mix(in srgb, var(--warn) 15%, var(--bg)); }
+  .tag.bad { color: var(--bad); background: color-mix(in srgb, var(--bad) 15%, var(--bg)); }
+  /* ---- Click-to-copy ---- */
+  .copy {
+    cursor: pointer;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: inherit;
+    font-family: var(--mono);
+    font-size: 0.85em;
+    padding: 0.1em 0.5em;
+    border-radius: 6px;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+    user-select: none;
+    vertical-align: baseline;
+    transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  }
+  .copy:hover { background: var(--accent-soft); border-color: var(--accent); }
+  .copy::after { content: "\29C9"; opacity: 0.55; font-size: 0.9em; }
+  .copy.copied { color: var(--good); border-color: var(--good); }
+  .copy.copied::after { content: "\2713"; opacity: 1; }
+  footer.doc { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--border); color: var(--muted); font-size: 13px; }
+  /* ---- Responsive ---- */
+  @media (max-width: 800px) {
+    .wrap { grid-template-columns: 1fr; gap: 16px; padding: 20px 16px 64px; }
+    nav.toc { position: static; max-height: none; border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 16px; background: var(--surface); }
+  }
+</style>
+<script>
+  // Click-to-copy. Any [data-copy] element copies its data-copy value
+  // (falling back to its text). Modern Clipboard API with a legacy
+  // execCommand fallback so it works on file:// and older browsers.
+  (function () {
+    function flash(el) {
+      el.classList.add("copied");
+      clearTimeout(el._copyTimer);
+      el._copyTimer = setTimeout(function () { el.classList.remove("copied"); }, 1200);
+    }
+    function legacyCopy(text, el) {
+      var ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "");
+      ta.style.position = "absolute";
+      ta.style.left = "-9999px";
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand("copy"); flash(el); } catch (e) {}
+      document.body.removeChild(ta);
+    }
+    document.addEventListener("click", function (e) {
+      var el = e.target.closest("[data-copy]");
+      if (!el) return;
+      var text = el.getAttribute("data-copy") || el.textContent.trim();
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(function () { flash(el); },
+          function () { legacyCopy(text, el); });
+      } else {
+        legacyCopy(text, el);
+      }
+    });
+  })();
+</script>

--- a/claude/.claude/skills/_shared/publish-artifact.sh
+++ b/claude/.claude/skills/_shared/publish-artifact.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# publish-artifact.sh — publish an HTML artifact to the project's QA Publish
+# Target and optionally post a PR comment with the live Pages link.
+#
+# Usage:
+#   publish-artifact.sh --html <path> --label <text>
+#                       [--pr <N>] [--comment-body <md-path>]
+#                       [--md-fallback-only <md-path>]
+#                       [--project-root <dir>]
+#
+# Reads the publish target from <project-root>/CLAUDE.md (## QA Publish Target).
+# If no valid target is declared, prints a warning and — when --pr and
+# --md-fallback-only are given — posts the Markdown body as a PR comment.
+# When a target is valid, uploads the HTML to <repo>/<subfolder>/<basename>
+# via the GitHub Contents API (create or update via SHA), prints the Pages
+# URL on stdout, and — when --pr is given — posts a PR comment whose first
+# line is the live link and whose remaining body is --comment-body (if any).
+
+set -euo pipefail
+
+die() { printf 'publish-artifact: %s\n' "$*" >&2; exit 1; }
+warn() { printf 'publish-artifact: %s\n' "$*" >&2; }
+
+html=""
+label=""
+pr=""
+comment_body=""
+md_fallback_only=""
+project_root="${PWD}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --html) html="$2"; shift 2 ;;
+    --label) label="$2"; shift 2 ;;
+    --pr) pr="$2"; shift 2 ;;
+    --comment-body) comment_body="$2"; shift 2 ;;
+    --md-fallback-only) md_fallback_only="$2"; shift 2 ;;
+    --project-root) project_root="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^set -euo/{/^#/p;}' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) die "unknown flag: $1" ;;
+  esac
+done
+
+[[ -n "${html}" ]] || die "--html is required"
+[[ -f "${html}" ]] || die "html file not found: ${html}"
+[[ -n "${label}" ]] || die "--label is required"
+[[ -d "${project_root}" ]] || die "project root not a directory: ${project_root}"
+
+cd "${project_root}"
+
+claude_md="CLAUDE.md"
+[[ -f "${claude_md}" ]] || die "no CLAUDE.md in ${project_root}"
+
+# Extract the first ```yaml fence under '## QA Publish Target'.
+yaml_block=$(awk '
+  /^## QA Publish Target[[:space:]]*$/ { found = 1; next }
+  found && /^```yaml[[:space:]]*$/ { in_yaml = 1; next }
+  in_yaml && /^```/ { exit }
+  in_yaml { print }
+' "${claude_md}")
+
+repo=""
+subfolder=""
+if [[ -n "${yaml_block}" ]]; then
+  repo=$(printf '%s\n' "${yaml_block}" | awk -F': *' '/^repo:/ {print $2; exit}' | tr -d '[:space:]')
+  subfolder=$(printf '%s\n' "${yaml_block}" | awk -F': *' '/^subfolder:/ {print $2; exit}' | tr -d '[:space:]')
+fi
+
+# Treat any placeholder (`<...>`) or invalid pattern as "undeclared".
+valid_target=1
+[[ -z "${repo}" || -z "${subfolder}" ]] && valid_target=0
+[[ "${repo}" == *"<"* || "${repo}" == *">"* ]] && valid_target=0
+[[ "${subfolder}" == *"<"* || "${subfolder}" == *">"* ]] && valid_target=0
+if [[ -n "${repo}" && ! "${repo}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+  warn "repo '${repo}' is not a valid <owner>/<name> — treating as undeclared"
+  valid_target=0
+fi
+if [[ "${subfolder}" == /* || "${subfolder}" == *".."* ]]; then
+  warn "subfolder '${subfolder}' is invalid — treating as undeclared"
+  valid_target=0
+fi
+
+if (( valid_target == 0 )); then
+  warn "no QA Publish Target declared in ${project_root}/CLAUDE.md — staying local"
+  if [[ -n "${pr}" && -n "${md_fallback_only}" && -f "${md_fallback_only}" ]]; then
+    gh pr comment "${pr}" --body-file "${md_fallback_only}" >/dev/null
+    warn "posted Markdown-only fallback PR comment to PR #${pr}"
+  fi
+  exit 0
+fi
+
+dest_path="${subfolder}/$(basename "${html}")"
+owner="${repo%%/*}"
+repo_name="${repo#*/}"
+
+source_repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo "unknown")
+short_sha=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+commit_msg="publish: ${dest_path} from ${source_repo}@${short_sha}"
+
+existing_sha=""
+if existing_json=$(gh api "repos/${repo}/contents/${dest_path}" 2>/dev/null); then
+  existing_sha=$(printf '%s' "${existing_json}" | jq -r '.sha // empty')
+fi
+
+content_b64=$(base64 < "${html}" | tr -d '\n')
+
+payload_file=$(mktemp)
+comment_file=""
+cleanup() {
+  rm -f "${payload_file}"
+  [[ -n "${comment_file}" ]] && rm -f "${comment_file}"
+  return 0
+}
+trap cleanup EXIT
+
+if [[ -n "${existing_sha}" ]]; then
+  jq -n \
+    --arg message "${commit_msg}" \
+    --arg content "${content_b64}" \
+    --arg sha "${existing_sha}" \
+    '{message: $message, content: $content, sha: $sha}' > "${payload_file}"
+else
+  jq -n \
+    --arg message "${commit_msg}" \
+    --arg content "${content_b64}" \
+    '{message: $message, content: $content}' > "${payload_file}"
+fi
+
+gh api -X PUT "repos/${repo}/contents/${dest_path}" --input "${payload_file}" >/dev/null
+
+pages_url="https://${owner}.github.io/${repo_name}/${dest_path}"
+echo "${pages_url}"
+
+if [[ -n "${pr}" ]]; then
+  comment_file=$(mktemp)
+  {
+    printf '**[Open %s on Pages →](%s)**\n\n' "${label}" "${pages_url}"
+    if [[ -n "${comment_body}" && -f "${comment_body}" ]]; then
+      cat "${comment_body}"
+    fi
+  } > "${comment_file}"
+  gh pr comment "${pr}" --body-file "${comment_file}" >/dev/null
+  warn "posted PR comment to PR #${pr}"
+fi

--- a/claude/.claude/skills/_shared/publish-artifact.sh
+++ b/claude/.claude/skills/_shared/publish-artifact.sh
@@ -78,13 +78,18 @@ valid_target=1
 [[ -z "${repo}" || -z "${subfolder}" ]] && valid_target=0
 [[ "${repo}" == *"<"* || "${repo}" == *">"* ]] && valid_target=0
 [[ "${subfolder}" == *"<"* || "${subfolder}" == *">"* ]] && valid_target=0
-if [[ -n "${repo}" && ! "${repo}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
-  warn "repo '${repo}' is not a valid <owner>/<name> — treating as undeclared"
-  valid_target=0
-fi
-if [[ "${subfolder}" == /* || "${subfolder}" == *".."* ]]; then
-  warn "subfolder '${subfolder}' is invalid — treating as undeclared"
-  valid_target=0
+# Only run the shape checks if the placeholder/empty checks above haven't
+# already disqualified the target — otherwise a placeholder value emits both
+# the shape warning and the "staying local" warning for the same condition.
+if (( valid_target == 1 )); then
+  if [[ ! "${repo}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+    warn "repo '${repo}' is not a valid <owner>/<name> — treating as undeclared"
+    valid_target=0
+  fi
+  if [[ "${subfolder}" == /* || "${subfolder}" == *".."* ]]; then
+    warn "subfolder '${subfolder}' is invalid — treating as undeclared"
+    valid_target=0
+  fi
 fi
 
 if (( valid_target == 0 )); then

--- a/claude/.claude/skills/_shared/publish-artifact.sh
+++ b/claude/.claude/skills/_shared/publish-artifact.sh
@@ -48,6 +48,10 @@ done
 [[ -f "${html}" ]] || die "html file not found: ${html}"
 [[ -n "${label}" ]] || die "--label is required"
 [[ -d "${project_root}" ]] || die "project root not a directory: ${project_root}"
+# Fail fast on missing optional-flag files — a silent skip hides typos and
+# leaves callers thinking the body was posted when it wasn't.
+[[ -z "${comment_body}" || -f "${comment_body}" ]] || die "--comment-body file not found: ${comment_body}"
+[[ -z "${md_fallback_only}" || -f "${md_fallback_only}" ]] || die "--md-fallback-only file not found: ${md_fallback_only}"
 
 cd "${project_root}"
 
@@ -85,7 +89,7 @@ fi
 
 if (( valid_target == 0 )); then
   warn "no QA Publish Target declared in ${project_root}/CLAUDE.md — staying local"
-  if [[ -n "${pr}" && -n "${md_fallback_only}" && -f "${md_fallback_only}" ]]; then
+  if [[ -n "${pr}" && -n "${md_fallback_only}" ]]; then
     gh pr comment "${pr}" --body-file "${md_fallback_only}" >/dev/null
     warn "posted Markdown-only fallback PR comment to PR #${pr}"
   fi
@@ -131,14 +135,22 @@ fi
 
 gh api -X PUT "repos/${repo}/contents/${dest_path}" --input "${payload_file}" >/dev/null
 
-pages_url="https://${owner}.github.io/${repo_name}/${dest_path}"
+# Pages URL assumes a project-pages repo served from the default branch. A
+# user/org-pages repo (named "<owner>.github.io") is served at the apex with
+# no <repo> path segment, so the project-pages template would be wrong.
+if [[ "${repo_name}" == "${owner}.github.io" ]]; then
+  warn "repo '${repo}' looks like a user/org-pages repo — the live URL omits the repo segment; verify GitHub Pages settings"
+  pages_url="https://${repo_name}/${dest_path}"
+else
+  pages_url="https://${owner}.github.io/${repo_name}/${dest_path}"
+fi
 echo "${pages_url}"
 
 if [[ -n "${pr}" ]]; then
   comment_file=$(mktemp)
   {
     printf '**[Open %s on Pages →](%s)**\n\n' "${label}" "${pages_url}"
-    if [[ -n "${comment_body}" && -f "${comment_body}" ]]; then
+    if [[ -n "${comment_body}" ]]; then
       cat "${comment_body}"
     fi
   } > "${comment_file}"

--- a/claude/.claude/skills/debrief/SKILL.md
+++ b/claude/.claude/skills/debrief/SKILL.md
@@ -100,15 +100,16 @@ docs/debriefs/summary/YYYY-MM-DD-[brief-topic].md
 
 #### Rendering the full debrief into HTML
 
-The house style lives in `template.html` (in this skill's directory). Produce the full debrief by filling that template:
+The document structure lives in `template.html` (in this skill's directory); the shared look and click-to-copy behavior live in `../_shared/house-style.html`. Produce the full debrief by filling the template and inlining the shared house style:
 
 1. **Read `template.html`** from this skill's directory and use it as the exact structure. Its head comment documents every token and section.
-2. **Inline the styles** — copy the template's `<style>` block verbatim into the output so the file is a single self-contained, portable `.html` (no external CSS, no build step). Do not link an external stylesheet.
+2. **Inline the shared house style** — read `../_shared/house-style.html` and copy its `<style>` block in place of the `<!-- HOUSE STYLE: ... <style> ... -->` marker in `<head>`, and its `<script>` block in place of the marker before `</body>`. The output must be a single self-contained, portable `.html` (no external assets, no build step). Do not link an external stylesheet.
 3. **Replace the `{{TOKENS}}`** (`{{PROJECT}}`, `{{TITLE}}`, `{{DATE}}`, `{{SCOPE}}`, `{{PRS}}`, `{{ISSUES}}`, `{{PRD_REFS}}`, and the section bodies `{{BUILT}}`, `{{ARCHITECTURE}}`, `{{TESTS}}`, `{{TOUR}}`). Drop metadata rows that don't apply.
-4. **Use the provided patterns:** Product Tour user stories become `<div class="story">` cards; the POODR spotlight and any flagged follow-ups become `<div class="callout">` blocks; architecture and data-flow structure becomes inline `<svg>` inside `<figure class="diagram">` — never ASCII art.
+4. **Use the shared components** (documented in `house-style.html`): Product Tour user stories become `<div class="story">` cards; the POODR spotlight and any flagged follow-ups become `<div class="callout">` blocks; architecture and data-flow structure becomes inline `<svg>` inside `<figure class="diagram">` — never ASCII art.
 5. **Make pasteable values click-to-copy.** Anything the reader will type into the app — seed credentials, emails, and key URLs in the Product Tour — should be a `<button type="button" class="copy" data-copy="VALUE">VALUE</button>` control so it copies on click. This removes the single biggest walkthrough papercut.
 6. **Keep the TOC in sync** with the sections you actually emit, and leave the high-value sections (What We Built, Product Tour) `open` by default.
-7. **JavaScript is limited to the bundled click-to-copy helper** (the trailing `<script>` in the template). Keep it; add no other scripts, frameworks, or dependencies. Collapsing uses native `<details>`/`<summary>`.
+7. **JavaScript is limited to the shared click-to-copy helper.** Add no other scripts, frameworks, or dependencies. Collapsing uses native `<details>`/`<summary>`.
+8. **Strip every instructional comment** — the template's head how-to block and all explanatory `<!-- ... -->` notes inside the body guide template-filling only and must not appear in the output. The artifact should contain real content plus the inlined house style, nothing else. (HTML comments do not nest, so a leftover instructional comment can break rendering, not just clutter it.)
 
 #### The summary file
 

--- a/claude/.claude/skills/debrief/template.html
+++ b/claude/.claude/skills/debrief/template.html
@@ -1,267 +1,37 @@
 <!DOCTYPE html>
 <!--
-  Debrief house-style template.
+  Debrief structural template.
 
-  The /debrief skill INLINES this file's <style> block into each generated
-  debrief so the output is a single self-contained, portable .html file
-  (no external CSS, no build step, no JavaScript).
+  The /debrief skill fills this skeleton, then inlines the shared house style
+  so the output is a single self-contained, portable .html file (no external
+  assets, no build step).
 
   How to use:
-  - Copy this whole document, then replace the {{TOKENS}} and the
-    annotated <!-- SECTION --> regions with real content.
-  - Keep the <style> block and the trailing <script> verbatim unless
-    intentionally evolving the house style. Do NOT link external assets —
-    inline only, so each output is a single portable file.
+  - Copy this whole document, then replace the {{TOKENS}} and the annotated
+    section regions with real content.
+  - Produce a CLEAN artifact: strip every instructional comment (this head
+    block and the explanatory notes inside the body). They guide
+    template-filling only and must not appear in the output. (HTML comments
+    do not nest, so a stray instructional comment can also break rendering.)
+  - Inline the shared house style: copy the style block from
+    ../_shared/house-style.html into the head (replacing the HOUSE STYLE
+    marker) and the script block before the closing body tag. Do NOT link
+    external assets.
   - Every major section is a <details> so the reader can collapse it.
     Leave the high-value sections (What We Built, Product Tour) open by
     default (the `open` attribute); collapse the rest.
-  - Use inline <svg> for architecture / data-flow diagrams. Never ASCII art.
+  - Use inline SVG for architecture / data-flow diagrams. Never ASCII art.
   - The table of contents is plain anchor links to each section's id.
-  - JavaScript is limited to the bundled click-to-copy helper — no
-    frameworks, no dependencies, no network. Make anything the reader will
-    paste (seed credentials, emails, URLs) a click-to-copy control:
-      <button type="button" class="copy" data-copy="admin@example.com">admin@example.com</button>
-    The value copied is data-copy (falling back to the element's text).
+  - Make anything the reader will paste (seed credentials, emails, URLs) a
+    click-to-copy control (the shared script powers it). The copied value is
+    the data-copy attribute, falling back to the element's text.
 -->
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{PROJECT}} — Debrief: {{TITLE}}</title>
-<style>
-  :root {
-    --bg: #ffffff;
-    --surface: #f6f8fa;
-    --surface-2: #eaeef2;
-    --border: #d0d7de;
-    --text: #1f2328;
-    --muted: #656d76;
-    --accent: #0969da;
-    --accent-soft: #ddf4ff;
-    --good: #1a7f37;
-    --warn: #9a6700;
-    --bad: #cf222e;
-    --code-bg: #f6f8fa;
-    --radius: 10px;
-    --maxw: 1080px;
-    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #0d1117;
-      --surface: #161b22;
-      --surface-2: #21262d;
-      --border: #30363d;
-      --text: #e6edf3;
-      --muted: #9198a1;
-      --accent: #4493f8;
-      --accent-soft: #121d2f;
-      --good: #3fb950;
-      --warn: #d29922;
-      --bad: #f85149;
-      --code-bg: #161b22;
-    }
-  }
-  * { box-sizing: border-box; }
-  html { scroll-behavior: smooth; }
-  body {
-    margin: 0;
-    background: var(--bg);
-    color: var(--text);
-    font-family: var(--sans);
-    line-height: 1.6;
-    font-size: 16px;
-  }
-  .wrap {
-    display: grid;
-    grid-template-columns: 240px minmax(0, 1fr);
-    gap: 40px;
-    max-width: var(--maxw);
-    margin: 0 auto;
-    padding: 32px 24px 96px;
-  }
-  /* ---- Table of contents ---- */
-  nav.toc {
-    position: sticky;
-    top: 24px;
-    align-self: start;
-    font-size: 14px;
-    max-height: calc(100vh - 48px);
-    overflow-y: auto;
-  }
-  nav.toc h2 {
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--muted);
-    margin: 0 0 12px;
-  }
-  nav.toc ol { list-style: none; margin: 0; padding: 0; }
-  nav.toc li { margin: 0 0 8px; }
-  nav.toc a {
-    color: var(--text);
-    text-decoration: none;
-    display: block;
-    padding: 4px 10px;
-    border-left: 2px solid transparent;
-    border-radius: 0 6px 6px 0;
-  }
-  nav.toc a:hover { background: var(--surface); border-left-color: var(--accent); color: var(--accent); }
-  /* ---- Main column ---- */
-  main { min-width: 0; }
-  header.doc {
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 24px;
-    margin-bottom: 8px;
-  }
-  .eyebrow {
-    color: var(--accent);
-    font-weight: 600;
-    font-size: 13px;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    margin: 0 0 6px;
-  }
-  header.doc h1 { font-size: 30px; line-height: 1.2; margin: 0 0 16px; }
-  dl.meta {
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    gap: 6px 16px;
-    margin: 0;
-    font-size: 14px;
-  }
-  dl.meta dt { color: var(--muted); font-weight: 600; }
-  dl.meta dd { margin: 0; }
-  /* ---- Sections ---- */
-  details.section {
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    margin: 16px 0;
-    background: var(--bg);
-    overflow: hidden;
-  }
-  details.section > summary {
-    cursor: pointer;
-    padding: 16px 20px;
-    font-size: 19px;
-    font-weight: 600;
-    background: var(--surface);
-    list-style: none;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-  }
-  details.section > summary::-webkit-details-marker { display: none; }
-  details.section > summary::before {
-    content: "›";
-    display: inline-block;
-    transition: transform 0.15s ease;
-    color: var(--muted);
-    font-size: 22px;
-    line-height: 1;
-  }
-  details.section[open] > summary::before { transform: rotate(90deg); }
-  .section-body { padding: 4px 20px 20px; }
-  h3 { font-size: 17px; margin: 24px 0 8px; }
-  h4 { font-size: 15px; margin: 18px 0 6px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
-  p { margin: 10px 0; }
-  a { color: var(--accent); }
-  code {
-    font-family: var(--mono);
-    font-size: 0.88em;
-    background: var(--surface-2);
-    padding: 0.15em 0.4em;
-    border-radius: 5px;
-  }
-  pre {
-    background: var(--code-bg);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 14px 16px;
-    overflow-x: auto;
-    font-size: 13px;
-    line-height: 1.5;
-  }
-  pre code { background: none; padding: 0; font-size: inherit; }
-  table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 14px; }
-  th, td { border: 1px solid var(--border); padding: 8px 12px; text-align: left; vertical-align: top; }
-  th { background: var(--surface); font-weight: 600; }
-  /* ---- Callouts ---- */
-  .callout {
-    border-left: 4px solid var(--accent);
-    background: var(--accent-soft);
-    border-radius: 0 var(--radius) var(--radius) 0;
-    padding: 12px 16px;
-    margin: 16px 0;
-  }
-  .callout.warn { border-left-color: var(--warn); background: color-mix(in srgb, var(--warn) 12%, var(--bg)); }
-  .callout.flag { border-left-color: var(--bad); background: color-mix(in srgb, var(--bad) 12%, var(--bg)); }
-  .callout .label { font-weight: 700; font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; display: block; margin-bottom: 4px; }
-  /* ---- Product tour story cards ---- */
-  .story {
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    margin: 16px 0;
-    overflow: hidden;
-  }
-  .story > .story-head {
-    background: var(--surface);
-    padding: 12px 16px;
-    font-weight: 600;
-    border-bottom: 1px solid var(--border);
-  }
-  .story .role-pill {
-    display: inline-block;
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--accent);
-    background: var(--accent-soft);
-    border-radius: 999px;
-    padding: 2px 10px;
-    margin-left: 8px;
-  }
-  .story ol { margin: 12px 0; padding-left: 28px; }
-  .story ol li { margin: 6px 0; }
-  .story .expect { color: var(--good); font-weight: 500; }
-  .story-body { padding: 4px 16px 14px; }
-  /* ---- Diagram figure ---- */
-  figure.diagram { margin: 18px 0; text-align: center; }
-  figure.diagram svg { max-width: 100%; height: auto; }
-  figure.diagram figcaption { color: var(--muted); font-size: 13px; margin-top: 8px; }
-  /* ---- Tags ---- */
-  .tag { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px; text-transform: uppercase; letter-spacing: 0.04em; }
-  .tag.good { color: var(--good); background: color-mix(in srgb, var(--good) 15%, var(--bg)); }
-  .tag.warn { color: var(--warn); background: color-mix(in srgb, var(--warn) 15%, var(--bg)); }
-  .tag.bad { color: var(--bad); background: color-mix(in srgb, var(--bad) 15%, var(--bg)); }
-  /* ---- Click-to-copy ---- */
-  .copy {
-    cursor: pointer;
-    border: 1px solid var(--border);
-    background: var(--surface-2);
-    color: inherit;
-    font-family: var(--mono);
-    font-size: 0.85em;
-    padding: 0.1em 0.5em;
-    border-radius: 6px;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4em;
-    user-select: none;
-    vertical-align: baseline;
-    transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
-  }
-  .copy:hover { background: var(--accent-soft); border-color: var(--accent); }
-  .copy::after { content: "\29C9"; opacity: 0.55; font-size: 0.9em; }
-  .copy.copied { color: var(--good); border-color: var(--good); }
-  .copy.copied::after { content: "\2713"; opacity: 1; }
-  footer.doc { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--border); color: var(--muted); font-size: 13px; }
-  /* ---- Responsive ---- */
-  @media (max-width: 800px) {
-    .wrap { grid-template-columns: 1fr; gap: 16px; padding: 20px 16px 64px; }
-    nav.toc { position: static; max-height: none; border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 16px; background: var(--surface); }
-  }
-</style>
+<!-- HOUSE STYLE: inline the <style> block from ../_shared/house-style.html here -->
 </head>
 <body>
 <div class="wrap">
@@ -351,39 +121,6 @@
     </footer>
   </main>
 </div>
-<script>
-  // Click-to-copy. Any [data-copy] element copies its data-copy value
-  // (falling back to its text). Modern Clipboard API with a legacy
-  // execCommand fallback so it works on file:// and older browsers.
-  (function () {
-    function flash(el) {
-      el.classList.add("copied");
-      clearTimeout(el._copyTimer);
-      el._copyTimer = setTimeout(function () { el.classList.remove("copied"); }, 1200);
-    }
-    function legacyCopy(text, el) {
-      var ta = document.createElement("textarea");
-      ta.value = text;
-      ta.setAttribute("readonly", "");
-      ta.style.position = "absolute";
-      ta.style.left = "-9999px";
-      document.body.appendChild(ta);
-      ta.select();
-      try { document.execCommand("copy"); flash(el); } catch (e) {}
-      document.body.removeChild(ta);
-    }
-    document.addEventListener("click", function (e) {
-      var el = e.target.closest("[data-copy]");
-      if (!el) return;
-      var text = el.getAttribute("data-copy") || el.textContent.trim();
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(text).then(function () { flash(el); },
-          function () { legacyCopy(text, el); });
-      } else {
-        legacyCopy(text, el);
-      }
-    });
-  })();
-</script>
+<!-- HOUSE STYLE: inline the <script> block from ../_shared/house-style.html here -->
 </body>
 </html>

--- a/claude/.claude/skills/qa-handoff/SKILL.md
+++ b/claude/.claude/skills/qa-handoff/SKILL.md
@@ -22,110 +22,52 @@ You are a senior developer preparing a hands-on testing guide for a QA colleague
 
 ## Output Format
 
-Generate a markdown document with the following sections. Follow this structure exactly.
+Render the handoff as a single self-contained **HTML** page using this skill's `template.html` and the shared house style — not a Markdown document. The tester opens it in a browser and gets click-to-copy logins, an interactive exploratory checklist, and a feedback form that exports Markdown.
 
----
+### Rendering
 
-### Header
+1. **Read `template.html`** (this skill's directory) for the structure and `../_shared/house-style.html` for the look. The template's head comment documents every token.
+2. **Inline the shared house style** — copy its `<style>` block in place of the `<!-- HOUSE STYLE ... -->` marker in `<head>`, and its `<script>` block in place of the second marker before `</body>`. The output must be a single self-contained `.html` (no external assets). Do not link a stylesheet.
+3. **Keep the feedback-export `<script>`** at the end of the template verbatim — it builds Markdown from the form and is this skill's own interactivity, separate from the shared click-to-copy helper.
+4. **Strip every instructional comment** from the output (the head how-to block and the body notes). The artifact must be clean. (HTML comments do not nest, so a leftover one can break rendering, not just clutter it.)
+5. **Fill the metadata tokens:** `{{PROJECT}}`, `{{TITLE}}` (e.g. `Phase N: Phase Title`), `{{DATE}}`, `{{BRANCH}}`, `{{COMMIT}}` (short SHA from `HEAD`), `{{DEBRIEF_REF}}` (path to the related debrief, or `N/A`).
+6. **Make every command, credential, and URL the tester will paste a click-to-copy control:** `<button type="button" class="copy" data-copy="VALUE">VALUE</button>`.
 
-```markdown
-# QA Handoff — Phase [N]: [Phase Title]
+### Section content
 
-**Project:** [project name]
-**Date:** [YYYY-MM-DD]
-**Branch:** `main` (or feature branch if applicable)
-**Commit:** [short SHA from HEAD]
-**Debrief reference:** [path to related debrief, or "N/A" if none]
-```
+Fill each section token with the content described below.
 
-### Section 1: What's New
+**What's New (`{{WHATS_NEW}}`)** — a plain-language summary of what was built, for someone who understands the product but isn't tracking implementation details. 2-4 short paragraphs; connect to the roadmap. No file paths, class names, or architecture jargon.
 
-A plain-language summary of what was built in this phase or milestone. Write for someone who understands the product but isn't tracking implementation details. 2-4 paragraphs covering the key features, changes, or capabilities added. Connect the work to the roadmap — where are we in the bigger picture?
+**Getting Current (`{{SETUP}}`)** — exact setup steps, each command a copy control: pull/install (`git pull`, `bundle install`, `bin/rails db:migrate`, `bin/rails db:seed`), whether a full `bin/rails db:reset` is needed, new gems/system packages, new env vars or credentials, and the command to start the app plus the URL to confirm it boots. List specifics — never "some dependencies changed." Say "None" where a category is unchanged.
 
-No file paths, class names, or architecture jargon.
+**Guided Walkthrough (`{{WALKTHROUGH}}`)** — one `<div class="story">` per scenario, in order. Each: a descriptive `.story-head` with a `.role-pill` for the user type; a copyable login (email + password from seed data) and starting URL; extremely literal numbered steps; and a `.expect` expected result precise enough that a deviation is obvious. Include at least one scenario per affected role. Read the project's `CLAUDE.md` for audience/viewport guidance (mobile-first user types, dual-audience designs) and add matching scenarios.
 
-### Section 2: Getting Current
+**Exploratory Testing (`{{EXPLORATORY}}`)** — an interactive `<ul class="checklist">`; each item `<li><label><input type="checkbox" data-check="..."> ...</label></li>`. Draw from debrief-flagged thin coverage, permission boundaries (accessing another user's data, role escalation), responsive/mobile checks for UI changes, and edge cases a developer might skip. The `data-check` text is included in the exported feedback, so make it self-describing.
 
-Specific setup instructions to get the tester's local environment up to date. Check for each of these and report concretely:
+**Test Suite (`{{TESTS}}`)** — commands to run the full suite and the targeted files most relevant to the new work, each a copy control. Note any known skips or expected failures.
 
-- Commands to pull and install (`git pull`, `bundle install`, `bin/rails db:migrate`, `bin/rails db:seed`)
-- Whether a full `bin/rails db:reset` is needed instead of `db:migrate`
-- New gem dependencies or system packages
-- New environment variables or credentials changes
-- The command to start the app (typically `bin/dev`) and the URL to confirm it boots
-
-Don't say "some dependencies changed" — list them. If nothing changed in a category, say "None."
-
-### Section 3: Guided Walkthrough
-
-A series of numbered scenarios the tester should work through in order. Each scenario includes:
-
-- **A descriptive name** as the heading
-- **Role** — which user type (from seed data)
-- **Login** — exact email and password from seed data
-- **URL** — exact starting URL
-- **Steps** — extremely literal, numbered instructions. The tester should be able to follow these without guessing.
-- **Expected behavior** — precise enough that a deviation is obvious.
-
-Include at least one scenario per user role affected by the new work. Read the project's `CLAUDE.md` for any audience-specific or viewport-specific testing guidance (e.g., mobile-first user types, dual-audience designs) and include appropriate scenarios.
-
-### Section 4: Exploratory Testing
-
-An open-ended checklist (using `- [ ]` checkboxes) of areas to poke at. The goal is to surface anything that feels off, confusing, or broken. Draw from:
-
-- Areas the debrief flagged as "thin test coverage" or "worth manual verification"
-- Permission boundary tests (accessing another user's data, role escalation)
-- Responsive/mobile checks if the work has UI changes
-- Edge cases a careful tester would try that a developer might not
-
-### Section 5: Test Suite Verification
-
-Commands to run the test suite, including both the full suite and targeted test files most relevant to the new work. Note any known skips or expected failures.
-
-```bash
-# Full suite
-bin/rails test
-
-# System tests
-bin/rails test:system
-
-# Phase-specific tests
-bin/rails test test/models/[relevant_file].rb
-```
-
-### Section 6: Feedback
-
-A section for the tester to fill in, with these subsections:
-
-- **Bugs or Broken Behavior** — anything that didn't work as described or produced an error
-- **Things That Felt Off** — UI confusion, clunky flows, odd wording
-- **Edge Cases or Gaps** — scenarios they tried that weren't covered
-- **Ideas or Suggestions** — feature ideas, UX improvements
-- **Other Notes** — anything else
-
-Include a note that brief bullet points and gut reactions are welcome — this section shouldn't feel like homework.
+**Feedback** — already built into the template (a literal form plus the "Copy feedback as Markdown" button). Do not tokenize or rewrite it; leave it as-is.
 
 ---
 
 ## Save Location
 
-Save the completed QA handoff to:
+Save the completed handoff to:
 
 ```text
-docs/qa-handoffs/YYYY-MM-DD-[brief-topic].md
+docs/qa-handoffs/YYYY-MM-DD-[brief-topic].html
 ```
 
-Create the `docs/qa-handoffs/` directory if it doesn't exist. Use the same date-and-slug convention as debriefs. After saving, tell the user:
+Create `docs/qa-handoffs/` if it doesn't exist; use the same date-and-slug convention as debriefs. After saving, open it so the result is in front of you (single self-contained file — instant, no server):
 
-```text
-QA handoff saved: docs/qa-handoffs/YYYY-MM-DD-[brief-topic].md
-
-Hand this file to your QA colleague. They should:
-1. Pull the latest code
-2. Follow the "Getting Current" section
-3. Work through the walkthrough and exploratory testing
-4. Fill in the Feedback section and return it to you
+```bash
+open docs/qa-handoffs/YYYY-MM-DD-[brief-topic].html
 ```
+
+> **Remote testers:** publishing the handoff to a shared host (so a tester can open it without cloning) is handled by the publish step, which reads the per-project target from the project's `CLAUDE.md`. With no target configured, the handoff stays local. Until publishing is wired, hand off the local file or its hosted copy.
+
+Then tell the user where the file is and that the tester should: follow **Getting Current**, work through the walkthrough and tick the exploratory checklist, then click **Copy feedback as Markdown** and paste the result back into the PR (or send it over).
 
 ## Tone & Approach
 

--- a/claude/.claude/skills/qa-handoff/SKILL.md
+++ b/claude/.claude/skills/qa-handoff/SKILL.md
@@ -35,7 +35,9 @@ Render the handoff as a single self-contained **HTML** page using this skill's `
     - **No QA template:** `https://github.com/<owner>/<repo>/issues/new`.
     - **No GitHub remote:** omit the CTA. Replace the Feedback section's button paragraph with a one-line note pointing at the project's actual tracker.
 5. **Fill the metadata tokens:** `{{PROJECT}}`, `{{TITLE}}` (e.g. `Phase N: Phase Title`), `{{DATE}}`, `{{BRANCH}}`, `{{COMMIT}}` (short SHA from `HEAD`), `{{DEBRIEF_REF}}` (path to the related debrief, or `N/A`), `{{REPORT_URL}}` (from step 4).
-6. **Make every command, credential, and URL the tester will paste a click-to-copy control:** `<button type="button" class="copy" data-copy="VALUE">VALUE</button>`.
+6. **Make every real command and URL the tester will paste a click-to-copy control:** `<button type="button" class="copy" data-copy="VALUE">VALUE</button>`.
+
+**Credentials.** The handoff HTML is a single file that is both committed and (with `--publish`) uploaded to a public QA host. A login may be a click-to-copy control only when it is a *reserved, non-routable example identity*: an RFC 2606 reserved domain (`example.com`/`.net`/`.org`) or the `.example` TLD, with any password an obviously-fake seed value (e.g. `password`). Such fakes are documentation, not credentials — and login is the most repetitive step, so keep them click-to-copy. Any real or real-looking login (real domain, actual person, live tenant, real password/token) must be a plain placeholder (`<code>&lt;your-admin-email&gt;</code>`), never a copy control; add a one-line note (local: seeded logins from `db/seeds.rb`; production: your own account). Never publish a real secret in any form.
 
 ### Section content
 
@@ -45,7 +47,7 @@ Fill each section token with the content described below.
 
 **Getting Current (`{{SETUP}}`)** — exact setup steps, each command a copy control: pull/install (`git pull`, `bundle install`, `bin/rails db:migrate`, `bin/rails db:seed`), whether a full `bin/rails db:reset` is needed, new gems/system packages, new env vars or credentials, and the command to start the app plus the URL to confirm it boots. List specifics — never "some dependencies changed." Say "None" where a category is unchanged.
 
-**Guided Walkthrough (`{{WALKTHROUGH}}`)** — one `<div class="story">` per scenario, in order. Each: a descriptive `.story-head` with a `.role-pill` for the user type; a copyable login (email + password from seed data) and starting URL; extremely literal numbered steps; and a `.expect` expected result precise enough that a deviation is obvious. Include at least one scenario per affected role. Read the project's `CLAUDE.md` for audience/viewport guidance (mobile-first user types, dual-audience designs) and add matching scenarios.
+**Guided Walkthrough (`{{WALKTHROUGH}}`)** — one `<div class="story">` per scenario, in order. Each: a descriptive `.story-head` with a `.role-pill` for the user type; a click-to-copy login when it is a reserved-example identity, otherwise a placeholder (see Credentials), plus a copyable starting URL; extremely literal numbered steps; and a `.expect` expected result precise enough that a deviation is obvious. Include at least one scenario per affected role. Read the project's `CLAUDE.md` for audience/viewport guidance (mobile-first user types, dual-audience designs) and add matching scenarios.
 
 **Exploratory Testing (`{{EXPLORATORY}}`)** — an interactive `<ul class="checklist">`; each item `<li><label><input type="checkbox" data-check="..."> ...</label></li>`. Draw from debrief-flagged thin coverage, permission boundaries (accessing another user's data, role escalation), responsive/mobile checks for UI changes, and edge cases a developer might skip. The checkboxes are a self-tracking aid the tester ticks as they go — make each item self-describing.
 

--- a/claude/.claude/skills/qa-handoff/SKILL.md
+++ b/claude/.claude/skills/qa-handoff/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: qa-handoff
-description: Generate a hands-on QA testing guide with walkthrough scenarios and exploratory testing checklist.
+description: Generate a hands-on QA testing guide with walkthrough scenarios and exploratory testing checklist. --publish uploads the HTML to the project's configured QA host.
 disable-model-invocation: true
+argument-hint: "[--publish] [--pr <N>]"
 ---
 
 # QA Handoff
@@ -68,9 +69,37 @@ Create `docs/qa-handoffs/` if it doesn't exist; use the same date-and-slug conve
 open docs/qa-handoffs/YYYY-MM-DD-[brief-topic].html
 ```
 
-> **Remote testers:** publishing the handoff to a shared host (so a tester can open it without cloning) is handled by the publish step, which reads the per-project target from the project's `CLAUDE.md`. With no target configured, the handoff stays local. Until publishing is wired, hand off the local file or its hosted copy.
-
 Then tell the user where the file is and that the tester should: follow **Getting Current**, work through the walkthrough and tick the exploratory checklist, then click **File a QA report** for any findings — that opens the project's QA issue form (with drag-and-drop screenshots and auto-tagging) so the report lands in the tracker.
+
+## Publishing for remote testers (`--publish`)
+
+A remote tester who is not cloning the repo needs a hosted copy. With `--publish`, the skill uploads the saved HTML to the project's configured QA host so the tester can open it from a URL.
+
+1. **Generate and save the HTML locally first** (the steps above). `--publish` operates on the saved file; it does not regenerate it.
+2. **Build a one-line blurb file** at `tmp/qa-handoff-comment.md` describing what is inside the HTML so a PR reader has context. One short paragraph — the HTML is the artifact, not a Markdown twin. Example:
+
+    ```markdown
+    Click-to-copy logins, interactive exploratory checklist, and a one-click
+    deep link to the project's QA report form are inside.
+    ```
+
+3. **Confirm before publishing.** This is outward-facing: it pushes a file to a shared repo and, when `--pr <N>` is given, posts a PR comment. Get explicit approval first.
+4. **Call the shared publish pipeline:**
+
+    ```bash
+    ~/.claude/skills/_shared/publish-artifact.sh \
+      --html docs/qa-handoffs/YYYY-MM-DD-[brief-topic].html \
+      --label "QA handoff: <Title>" \
+      [--pr <N>] \
+      [--comment-body tmp/qa-handoff-comment.md]
+    ```
+
+    Behaviour:
+    - **Target declared, no `--pr`** → uploads the HTML, prints the live Pages URL. Share that URL with the tester.
+    - **Target declared, `--pr <N>` given** → also posts a PR comment with the live link above the blurb.
+    - **Target undeclared** → prints a warning and stays local. No PR comment (`--md-fallback-only` is not used here because the HTML is the artifact — a Markdown twin would lose the click-to-copy logins and the interactive checklist that make the handoff useful).
+
+5. Report back to the user with the Pages URL (and PR-comment confirmation when applicable).
 
 ## Tone & Approach
 

--- a/claude/.claude/skills/qa-handoff/SKILL.md
+++ b/claude/.claude/skills/qa-handoff/SKILL.md
@@ -22,15 +22,18 @@ You are a senior developer preparing a hands-on testing guide for a QA colleague
 
 ## Output Format
 
-Render the handoff as a single self-contained **HTML** page using this skill's `template.html` and the shared house style — not a Markdown document. The tester opens it in a browser and gets click-to-copy logins, an interactive exploratory checklist, and a feedback form that exports Markdown.
+Render the handoff as a single self-contained **HTML** page using this skill's `template.html` and the shared house style — not a Markdown document. The tester opens it in a browser and gets click-to-copy logins, an interactive exploratory checklist, and a one-click link to the project's existing QA issue form for reporting findings.
 
 ### Rendering
 
 1. **Read `template.html`** (this skill's directory) for the structure and `../_shared/house-style.html` for the look. The template's head comment documents every token.
 2. **Inline the shared house style** — copy its `<style>` block in place of the `<!-- HOUSE STYLE ... -->` marker in `<head>`, and its `<script>` block in place of the second marker before `</body>`. The output must be a single self-contained `.html` (no external assets). Do not link a stylesheet.
-3. **Keep the feedback-export `<script>`** at the end of the template verbatim — it builds Markdown from the form and is this skill's own interactivity, separate from the shared click-to-copy helper.
-4. **Strip every instructional comment** from the output (the head how-to block and the body notes). The artifact must be clean. (HTML comments do not nest, so a leftover one can break rendering, not just clutter it.)
-5. **Fill the metadata tokens:** `{{PROJECT}}`, `{{TITLE}}` (e.g. `Phase N: Phase Title`), `{{DATE}}`, `{{BRANCH}}`, `{{COMMIT}}` (short SHA from `HEAD`), `{{DEBRIEF_REF}}` (path to the related debrief, or `N/A`).
+3. **Strip every instructional comment** from the output (the head how-to block and the body notes). The artifact must be clean. (HTML comments do not nest, so a leftover one can break rendering, not just clutter it.)
+4. **Resolve the QA report URL (`{{REPORT_URL}}`).** Find the project's GitHub repo via `gh repo view --json nameWithOwner --jq .nameWithOwner`. Look in `.github/ISSUE_TEMPLATE/` for a QA template (filename matching `qa`, case-insensitive — prefer YAML issue forms over plain Markdown). Build the URL:
+    - **QA template found:** `https://github.com/<owner>/<repo>/issues/new?template=<filename>`. Leave the title blank so the template's own `QA: <short description>` placeholder guides the tester.
+    - **No QA template:** `https://github.com/<owner>/<repo>/issues/new`.
+    - **No GitHub remote:** omit the CTA. Replace the Feedback section's button paragraph with a one-line note pointing at the project's actual tracker.
+5. **Fill the metadata tokens:** `{{PROJECT}}`, `{{TITLE}}` (e.g. `Phase N: Phase Title`), `{{DATE}}`, `{{BRANCH}}`, `{{COMMIT}}` (short SHA from `HEAD`), `{{DEBRIEF_REF}}` (path to the related debrief, or `N/A`), `{{REPORT_URL}}` (from step 4).
 6. **Make every command, credential, and URL the tester will paste a click-to-copy control:** `<button type="button" class="copy" data-copy="VALUE">VALUE</button>`.
 
 ### Section content
@@ -43,11 +46,11 @@ Fill each section token with the content described below.
 
 **Guided Walkthrough (`{{WALKTHROUGH}}`)** — one `<div class="story">` per scenario, in order. Each: a descriptive `.story-head` with a `.role-pill` for the user type; a copyable login (email + password from seed data) and starting URL; extremely literal numbered steps; and a `.expect` expected result precise enough that a deviation is obvious. Include at least one scenario per affected role. Read the project's `CLAUDE.md` for audience/viewport guidance (mobile-first user types, dual-audience designs) and add matching scenarios.
 
-**Exploratory Testing (`{{EXPLORATORY}}`)** — an interactive `<ul class="checklist">`; each item `<li><label><input type="checkbox" data-check="..."> ...</label></li>`. Draw from debrief-flagged thin coverage, permission boundaries (accessing another user's data, role escalation), responsive/mobile checks for UI changes, and edge cases a developer might skip. The `data-check` text is included in the exported feedback, so make it self-describing.
+**Exploratory Testing (`{{EXPLORATORY}}`)** — an interactive `<ul class="checklist">`; each item `<li><label><input type="checkbox" data-check="..."> ...</label></li>`. Draw from debrief-flagged thin coverage, permission boundaries (accessing another user's data, role escalation), responsive/mobile checks for UI changes, and edge cases a developer might skip. The checkboxes are a self-tracking aid the tester ticks as they go — make each item self-describing.
 
 **Test Suite (`{{TESTS}}`)** — commands to run the full suite and the targeted files most relevant to the new work, each a copy control. Note any known skips or expected failures.
 
-**Feedback** — already built into the template (a literal form plus the "Copy feedback as Markdown" button). Do not tokenize or rewrite it; leave it as-is.
+**Feedback** — already built into the template: a CTA button linking to the QA issue form via `{{REPORT_URL}}`. Do not reconstruct the form. If you fell back to the "no GitHub remote" case in step 4, replace the button paragraph with the tracker note instead.
 
 ---
 
@@ -67,7 +70,7 @@ open docs/qa-handoffs/YYYY-MM-DD-[brief-topic].html
 
 > **Remote testers:** publishing the handoff to a shared host (so a tester can open it without cloning) is handled by the publish step, which reads the per-project target from the project's `CLAUDE.md`. With no target configured, the handoff stays local. Until publishing is wired, hand off the local file or its hosted copy.
 
-Then tell the user where the file is and that the tester should: follow **Getting Current**, work through the walkthrough and tick the exploratory checklist, then click **Copy feedback as Markdown** and paste the result back into the PR (or send it over).
+Then tell the user where the file is and that the tester should: follow **Getting Current**, work through the walkthrough and tick the exploratory checklist, then click **File a QA report** for any findings — that opens the project's QA issue form (with drag-and-drop screenshots and auto-tagging) so the report lands in the tracker.
 
 ## Tone & Approach
 

--- a/claude/.claude/skills/qa-handoff/template.html
+++ b/claude/.claude/skills/qa-handoff/template.html
@@ -16,13 +16,12 @@
     ../_shared/house-style.html into the head (replacing the HOUSE STYLE
     marker) and its script block where the second HOUSE STYLE marker sits
     (before the closing body tag). Do NOT link external assets.
-  - KEEP the feedback-export script at the very end verbatim — it is this
-    skill's own interactivity (builds Markdown from the form) and is separate
-    from the shared click-to-copy helper.
   - Make every command, credential, and URL the tester will paste a
     click-to-copy control: a button with class "copy" and a data-copy value.
-  - The feedback form fields are LITERAL (the tester fills them live); they are
-    not tokens. Keep them and the export button as-is.
+  - The Feedback section is a CALL TO ACTION to the project's existing QA
+    issue form, not a reimplementation. Fill {{REPORT_URL}} with the deep
+    link (see the skill instructions). If no QA template exists, fall back to
+    the plain "issues/new" URL or a tracker note.
 -->
 <html lang="en">
 <head>
@@ -106,39 +105,10 @@
     </details>
 
     <details class="section" id="feedback" open>
-      <summary>Feedback</summary>
+      <summary>Found something? File a QA report</summary>
       <div class="section-body">
-        <p>Fill in whatever's relevant — brief bullets and gut reactions are welcome. When done, click <strong>Copy feedback as Markdown</strong> and paste it back into the pull request or send it over.</p>
-        <form id="qa-feedback" onsubmit="return false">
-          <div class="field">
-            <label for="fb-tester">Your name (optional)</label>
-            <input type="text" id="fb-tester" placeholder="e.g. Nathan">
-          </div>
-          <div class="field">
-            <label for="fb-bugs">Bugs or broken behavior</label>
-            <textarea id="fb-bugs" data-fb="Bugs or Broken Behavior"></textarea>
-          </div>
-          <div class="field">
-            <label for="fb-off">Things that felt off</label>
-            <textarea id="fb-off" data-fb="Things That Felt Off"></textarea>
-          </div>
-          <div class="field">
-            <label for="fb-gaps">Edge cases or gaps</label>
-            <textarea id="fb-gaps" data-fb="Edge Cases or Gaps"></textarea>
-          </div>
-          <div class="field">
-            <label for="fb-ideas">Ideas or suggestions</label>
-            <textarea id="fb-ideas" data-fb="Ideas or Suggestions"></textarea>
-          </div>
-          <div class="field">
-            <label for="fb-other">Other notes</label>
-            <textarea id="fb-other" data-fb="Other Notes"></textarea>
-          </div>
-          <div class="actions">
-            <button type="button" class="btn" id="fb-copy">Copy feedback as Markdown</button>
-            <span class="form-status" id="fb-status"></span>
-          </div>
-        </form>
+        <p>Report findings using the project's QA issue form — it has dedicated fields for steps, expected vs. actual behavior, screenshots (drag-and-drop), locale, browser/device, and more, and the issue is auto-tagged for triage.</p>
+        <p><a class="btn" href="{{REPORT_URL}}" target="_blank" rel="noopener">File a QA report &rarr;</a></p>
       </div>
     </details>
 
@@ -148,54 +118,5 @@
   </main>
 </div>
 <!-- HOUSE STYLE: inline the <script> block from ../_shared/house-style.html here -->
-<script>
-  // Feedback export (qa-handoff only): assemble the form + exploratory
-  // checklist into Markdown and copy it, so the tester pastes it back.
-  (function () {
-    var btn = document.getElementById("fb-copy");
-    if (!btn) return;
-    function legacyCopy(text, cb) {
-      var ta = document.createElement("textarea");
-      ta.value = text;
-      ta.setAttribute("readonly", "");
-      ta.style.position = "absolute";
-      ta.style.left = "-9999px";
-      document.body.appendChild(ta);
-      ta.select();
-      try { document.execCommand("copy"); cb(); } catch (e) {}
-      document.body.removeChild(ta);
-    }
-    btn.addEventListener("click", function () {
-      var lines = ["## QA Feedback — " + document.title, ""];
-      var tester = document.getElementById("fb-tester");
-      if (tester && tester.value.trim()) lines.push("**Tester:** " + tester.value.trim(), "");
-      var checks = document.querySelectorAll("[data-check]");
-      if (checks.length) {
-        lines.push("### Exploratory checklist", "");
-        checks.forEach(function (c) {
-          lines.push("- [" + (c.checked ? "x" : " ") + "] " + c.getAttribute("data-check"));
-        });
-        lines.push("");
-      }
-      document.querySelectorAll("[data-fb]").forEach(function (t) {
-        lines.push("### " + t.getAttribute("data-fb"), "", t.value.trim() || "_None_", "");
-      });
-      var md = lines.join("\n");
-      var done = function () {
-        var s = document.getElementById("fb-status");
-        if (s) {
-          s.textContent = "Copied — paste it into the PR or send it back.";
-          clearTimeout(s._t);
-          s._t = setTimeout(function () { s.textContent = ""; }, 5000);
-        }
-      };
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(md).then(done, function () { legacyCopy(md, done); });
-      } else {
-        legacyCopy(md, done);
-      }
-    });
-  })();
-</script>
 </body>
 </html>

--- a/claude/.claude/skills/qa-handoff/template.html
+++ b/claude/.claude/skills/qa-handoff/template.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<!--
+  QA handoff structural template.
+
+  The /qa-handoff skill fills this skeleton, then inlines the shared house
+  style so the output is a single self-contained, portable .html file.
+
+  How to use:
+  - Copy this whole document, then replace the {{TOKENS}} and the annotated
+    section regions with real content.
+  - Produce a CLEAN artifact: strip every instructional comment (this head
+    block and the explanatory notes in the body). They guide template-filling
+    only and must not appear in the output. (HTML comments do not nest, so a
+    stray instructional comment can also break rendering.)
+  - Inline the shared house style: copy the style block from
+    ../_shared/house-style.html into the head (replacing the HOUSE STYLE
+    marker) and its script block where the second HOUSE STYLE marker sits
+    (before the closing body tag). Do NOT link external assets.
+  - KEEP the feedback-export script at the very end verbatim — it is this
+    skill's own interactivity (builds Markdown from the form) and is separate
+    from the shared click-to-copy helper.
+  - Make every command, credential, and URL the tester will paste a
+    click-to-copy control: a button with class "copy" and a data-copy value.
+  - The feedback form fields are LITERAL (the tester fills them live); they are
+    not tokens. Keep them and the export button as-is.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{PROJECT}} — QA Handoff: {{TITLE}}</title>
+<!-- HOUSE STYLE: inline the <style> block from ../_shared/house-style.html here -->
+</head>
+<body>
+<div class="wrap">
+
+  <nav class="toc">
+    <h2>Contents</h2>
+    <ol>
+      <li><a href="#new">What's New</a></li>
+      <li><a href="#setup">Getting Current</a></li>
+      <li><a href="#walkthrough">Guided Walkthrough</a></li>
+      <li><a href="#exploratory">Exploratory Testing</a></li>
+      <li><a href="#tests">Test Suite</a></li>
+      <li><a href="#feedback">Feedback</a></li>
+    </ol>
+  </nav>
+
+  <main>
+    <header class="doc">
+      <p class="eyebrow">{{PROJECT}} · QA Handoff</p>
+      <h1>{{TITLE}}</h1>
+      <dl class="meta">
+        <dt>Project</dt><dd>{{PROJECT}}</dd>
+        <dt>Date</dt><dd>{{DATE}}</dd>
+        <dt>Branch</dt><dd>{{BRANCH}}</dd>
+        <dt>Commit</dt><dd>{{COMMIT}}</dd>
+        <dt>Debrief</dt><dd>{{DEBRIEF_REF}}</dd>
+      </dl>
+    </header>
+
+    <details class="section" id="new" open>
+      <summary>What's New</summary>
+      <div class="section-body">
+        <!-- Plain-language summary of what was built; connect to the roadmap. No file paths / jargon. -->
+        {{WHATS_NEW}}
+      </div>
+    </details>
+
+    <details class="section" id="setup" open>
+      <summary>Getting Current</summary>
+      <div class="section-body">
+        <!-- Exact setup steps. Make each command a click-to-copy control, e.g.:
+             <button type="button" class="copy" data-copy="git pull">git pull</button>
+             List new deps / env vars / whether a db reset is needed, or "None". -->
+        {{SETUP}}
+      </div>
+    </details>
+
+    <details class="section" id="walkthrough" open>
+      <summary>Guided Walkthrough</summary>
+      <div class="section-body">
+        <!-- One <div class="story"> per scenario; copyable creds/URLs; .expect for expected result. -->
+        {{WALKTHROUGH}}
+      </div>
+    </details>
+
+    <details class="section" id="exploratory" open>
+      <summary>Exploratory Testing</summary>
+      <div class="section-body">
+        <!-- Open-ended things to poke at, as an interactive checklist:
+        <ul class="checklist">
+          <li><label><input type="checkbox" data-check="Try accessing another user's record"> Try accessing another user's record</label></li>
+        </ul>
+        The data-check value is exported with the feedback. -->
+        {{EXPLORATORY}}
+      </div>
+    </details>
+
+    <details class="section" id="tests">
+      <summary>Test Suite</summary>
+      <div class="section-body">
+        <!-- Commands to run the suite; make each a click-to-copy control. Note known skips. -->
+        {{TESTS}}
+      </div>
+    </details>
+
+    <details class="section" id="feedback" open>
+      <summary>Feedback</summary>
+      <div class="section-body">
+        <p>Fill in whatever's relevant — brief bullets and gut reactions are welcome. When done, click <strong>Copy feedback as Markdown</strong> and paste it back into the pull request or send it over.</p>
+        <form id="qa-feedback" onsubmit="return false">
+          <div class="field">
+            <label for="fb-tester">Your name (optional)</label>
+            <input type="text" id="fb-tester" placeholder="e.g. Nathan">
+          </div>
+          <div class="field">
+            <label for="fb-bugs">Bugs or broken behavior</label>
+            <textarea id="fb-bugs" data-fb="Bugs or Broken Behavior"></textarea>
+          </div>
+          <div class="field">
+            <label for="fb-off">Things that felt off</label>
+            <textarea id="fb-off" data-fb="Things That Felt Off"></textarea>
+          </div>
+          <div class="field">
+            <label for="fb-gaps">Edge cases or gaps</label>
+            <textarea id="fb-gaps" data-fb="Edge Cases or Gaps"></textarea>
+          </div>
+          <div class="field">
+            <label for="fb-ideas">Ideas or suggestions</label>
+            <textarea id="fb-ideas" data-fb="Ideas or Suggestions"></textarea>
+          </div>
+          <div class="field">
+            <label for="fb-other">Other notes</label>
+            <textarea id="fb-other" data-fb="Other Notes"></textarea>
+          </div>
+          <div class="actions">
+            <button type="button" class="btn" id="fb-copy">Copy feedback as Markdown</button>
+            <span class="form-status" id="fb-status"></span>
+          </div>
+        </form>
+      </div>
+    </details>
+
+    <footer class="doc">
+      Generated by the <code>/qa-handoff</code> skill · {{DATE}}
+    </footer>
+  </main>
+</div>
+<!-- HOUSE STYLE: inline the <script> block from ../_shared/house-style.html here -->
+<script>
+  // Feedback export (qa-handoff only): assemble the form + exploratory
+  // checklist into Markdown and copy it, so the tester pastes it back.
+  (function () {
+    var btn = document.getElementById("fb-copy");
+    if (!btn) return;
+    function legacyCopy(text, cb) {
+      var ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "");
+      ta.style.position = "absolute";
+      ta.style.left = "-9999px";
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand("copy"); cb(); } catch (e) {}
+      document.body.removeChild(ta);
+    }
+    btn.addEventListener("click", function () {
+      var lines = ["## QA Feedback — " + document.title, ""];
+      var tester = document.getElementById("fb-tester");
+      if (tester && tester.value.trim()) lines.push("**Tester:** " + tester.value.trim(), "");
+      var checks = document.querySelectorAll("[data-check]");
+      if (checks.length) {
+        lines.push("### Exploratory checklist", "");
+        checks.forEach(function (c) {
+          lines.push("- [" + (c.checked ? "x" : " ") + "] " + c.getAttribute("data-check"));
+        });
+        lines.push("");
+      }
+      document.querySelectorAll("[data-fb]").forEach(function (t) {
+        lines.push("### " + t.getAttribute("data-fb"), "", t.value.trim() || "_None_", "");
+      });
+      var md = lines.join("\n");
+      var done = function () {
+        var s = document.getElementById("fb-status");
+        if (s) {
+          s.textContent = "Copied — paste it into the PR or send it back.";
+          clearTimeout(s._t);
+          s._t = setTimeout(function () { s.textContent = ""; }, 5000);
+        }
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(md).then(done, function () { legacyCopy(md, done); });
+      } else {
+        legacyCopy(md, done);
+      }
+    });
+  })();
+</script>
+</body>
+</html>

--- a/claude/.claude/skills/walkthrough/SKILL.md
+++ b/claude/.claude/skills/walkthrough/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[PR-number-or-branch] [--publish]"
 
 Generate a concise, click-by-click manual walkthrough of the current branch's user-facing changes, so the human orchestrator can exercise the feature in a browser **before** the formal `/review-pr`. Seeing a feature work is faster than reading code or a PR description for catching UX problems.
 
-This skill does not modify code or perform code review. With `--publish` it posts the walkthrough as a PR comment; otherwise it only writes a local scratch file.
+This skill does not modify code or perform code review. With `--publish` it renders a rich HTML version, publishes it to the project's configured QA host (when one is declared in the project's `CLAUDE.md`), and posts a PR comment linking to it with the Markdown body as a collapsible fallback. Without `--publish` it only writes local scratch files.
 
 **Where it sits in the workflow — two slots:**
 
@@ -87,16 +87,48 @@ Use the template below. Principles:
 
 ## Publishing the final walkthrough (`--publish`)
 
-Run once, after `/review-pr` and any review fixes — normally just before merge, but also valid on an **already-merged** PR to backfill a walkthrough that was missed. This posts the final walkthrough as a comment on the PR, where the QA tester can follow it after deploy.
+Run once, after `/review-pr` and any review fixes — normally just before merge, but also valid on an **already-merged** PR to backfill a walkthrough that was missed. This renders the walkthrough as rich HTML, publishes it to the project's configured QA host (if any), and posts a PR comment with the live link and a collapsible Markdown fallback.
 
 1. **Resolve the PR.** Use the PR number or branch given as an argument; otherwise find the PR for the current branch (`gh pr view`). The PR may be **open or merged** — both are valid publish targets. Only stop if no PR exists at all.
 2. **Re-run the gate.** If the change is not user-facing (the **Gate** step above), there is nothing to publish — say so and stop.
-3. **Regenerate from the PR diff.** Do not reuse a possibly-stale scratch file — review may have changed the code, and on a merged PR the branch is likely deleted. Rebuild the walkthrough from `gh pr diff <N>` exactly as steps 1–5 describe, so the published copy matches the code that merged. Save the regenerated document to the project's `tmp/` directory — `tmp/pr-<N>-walkthrough-published.md`, not the system `/tmp` — so the user can open it easily alongside the project.
-4. **Prepend a production-verification note** — a short block quote at the very top stating that QA testers verifying on production should use the production app and their own account in place of the local server and seed logins; the steps and expected results are identical. This is the normal case for a post-merge publish, since the feature is already deployed.
-5. **Decide who to notify.** A PR comment only notifies people already participating in the PR. If a QA reporter/tester should follow the walkthrough and is not already a participant (e.g. they were never @-mentioned in the PR body), @-mention their handle in the comment so they get a directed notification. Get the handle from the linked QA report's author, the PR body, or by asking the user; if in doubt, ask.
-6. **Confirm before posting.** Show the final document — including any @-mention — to the user and get explicit approval. Posting a PR comment is outward-facing and notifies others — never post without a clear yes.
-7. **Post the comment:** `gh pr comment <N> --body-file tmp/pr-<N>-walkthrough-published.md`.
-8. Confirm to the user that it is posted, and who will be notified (PR participants, plus anyone @-mentioned).
+3. **Regenerate from the PR diff.** Do not reuse a possibly-stale scratch file — review may have changed the code, and on a merged PR the branch is likely deleted. Rebuild the walkthrough content from `gh pr diff <N>` exactly as steps 1–5 describe, so the published copy matches the code that merged.
+4. **Save the Markdown twin** to `tmp/pr-<N>-walkthrough-published.md` (the project-local `tmp/`, not the system `/tmp`). This Markdown is what fills the PR-comment fallback and is also used as the no-target fallback if the project has not declared a QA Publish Target. Prepend a short block-quote note at the very top: testers verifying on production should use the production app and their own account in place of the local server and seed logins; the steps and expected results are identical. This is the normal case for a post-merge publish.
+5. **Render the HTML twin** using this skill's `template.html` and the shared house style:
+    - Read `template.html` (this skill's directory) for the structure and `../_shared/house-style.html` for the look.
+    - Inline the shared house style — copy its `<style>` block in place of the `<!-- HOUSE STYLE ... -->` marker in `<head>`, and its `<script>` block in place of the second marker before `</body>`. The output must be a single self-contained `.html` (no external assets).
+    - Strip every instructional comment from the output (the head how-to block and the body notes). The artifact must be clean.
+    - Fill the metadata tokens: `{{PROJECT}}`, `{{PR}}`, `{{PR_LINK}}` (Markdown link to the PR), `{{FEATURE}}` (short feature name), `{{BRANCH}}`, `{{COMMIT}}` (short SHA), `{{DATE}}`, `{{ESTIMATE}}`.
+    - Keep the production-verification callout in the HTML version too (it is part of the template). Convert the Markdown setup, logins, parts, not-browser-testable, and cleanup content into the HTML structure described inline in the template. Every command/credential/URL the tester will paste is a `<button type="button" class="copy" data-copy="VALUE">VALUE</button>` control.
+    - Save to `tmp/pr-<N>-walkthrough-published.html`.
+6. **Build the PR-comment body** at `tmp/pr-<N>-walkthrough-comment.md`: a `<details>` block wrapping the Markdown twin so the link sits above and the Markdown is a collapsible fallback below.
+
+    ```markdown
+    <details><summary>Markdown fallback</summary>
+
+    <contents of tmp/pr-<N>-walkthrough-published.md>
+
+    </details>
+    ```
+
+    Do not include the link yourself — the publish pipeline prepends it.
+7. **Decide who to notify.** A PR comment only notifies people already participating in the PR. If a QA reporter/tester should follow the walkthrough and is not already a participant (e.g. they were never @-mentioned in the PR body), @-mention their handle either inside the comment body file or as a one-line appendix at the end of it. Get the handle from the linked QA report's author, the PR body, or by asking the user; if in doubt, ask.
+8. **Confirm before posting.** Show the final HTML (open it locally with `open`) and the comment-body Markdown to the user and get explicit approval. Posting a PR comment is outward-facing and notifies others — never post without a clear yes.
+9. **Publish.** Call the shared publish pipeline. It resolves the project's QA Publish Target, uploads the HTML when one is declared, and posts the PR comment.
+
+    ```bash
+    ~/.claude/skills/_shared/publish-artifact.sh \
+      --html tmp/pr-<N>-walkthrough-published.html \
+      --label "PR #<N> walkthrough" \
+      --pr <N> \
+      --comment-body tmp/pr-<N>-walkthrough-comment.md \
+      --md-fallback-only tmp/pr-<N>-walkthrough-published.md
+    ```
+
+    Behaviour:
+    - **Target declared** → uploads the HTML, posts a PR comment with the live link above the collapsible Markdown body.
+    - **Target undeclared** → prints a warning, posts the Markdown body alone as the PR comment (the pre-HTML-pivot behaviour).
+
+10. Confirm to the user that it is posted, share the Pages URL (if any) printed by the pipeline, and note who will be notified (PR participants, plus anyone @-mentioned).
 
 ## Document template
 

--- a/claude/.claude/skills/walkthrough/SKILL.md
+++ b/claude/.claude/skills/walkthrough/SKILL.md
@@ -52,7 +52,7 @@ If the change is user-facing — or a mix where the UI surface is worth exercisi
 
 - From the changed views/controllers/routes, determine which screens and user journeys changed.
 - Identify every user role/persona that touches the changed flows.
-- Find concrete test accounts for each persona by reading the project's seed data (e.g. `db/seeds.rb`), fixtures, or factories. Use exact credentials.
+- Find concrete test accounts for each persona by reading the project's seed data (e.g. `db/seeds.rb`), fixtures, or factories. Use exact credentials. Reserved-example logins (`@example.com` and friends) stay click-to-copy when published; real-looking ones become placeholders — see Credentials in published artifacts under Publishing.
 - Determine the local login mechanism by reading the project (password, magic link via a dev mail catcher, a dev-only shortcut) and describe it literally.
 - Read `CLAUDE.md` for project-specific concerns to fold in: default locale and bilingual requirements, mobile-first/viewport rules, theme, accessibility.
 
@@ -89,6 +89,8 @@ Use the template below. Principles:
 
 Run once, after `/review-pr` and any review fixes — normally just before merge, but also valid on an **already-merged** PR to backfill a walkthrough that was missed. This renders the walkthrough as rich HTML, publishes it to the project's configured QA host (if any), and posts a PR comment with the live link and a collapsible Markdown fallback.
 
+**Credentials in published artifacts.** A login may be a click-to-copy control only when it is a *reserved, non-routable example identity*: the email domain is an RFC 2606 reserved-for-documentation domain (`example.com`, `example.net`, `example.org`) or the `.example` TLD, and any accompanying password is an obviously-fake seed value (e.g. `password`), not a real secret. Such logins are documentation, not credentials — guaranteed unregisterable and non-deliverable — so publishing them as copy controls is safe and removes the single most repetitive step in any walkthrough (login). Anything else — a real or real-looking domain, an actual person's address, a live tenant, or a real password/token/API key — must be a plain-text placeholder (`<code>&lt;your-admin-email&gt;</code>`), never a copy control; pair it with a one-line note (local testers use the seeded login from `db/seeds.rb`; production testers use their own account). Never publish a real password, token, or secret in any form. The publish step stays human-gated regardless.
+
 1. **Resolve the PR.** Use the PR number or branch given as an argument; otherwise find the PR for the current branch (`gh pr view`). The PR may be **open or merged** — both are valid publish targets. Only stop if no PR exists at all.
 2. **Re-run the gate.** If the change is not user-facing (the **Gate** step above), there is nothing to publish — say so and stop.
 3. **Regenerate from the PR diff.** Do not reuse a possibly-stale scratch file — review may have changed the code, and on a merged PR the branch is likely deleted. Rebuild the walkthrough content from `gh pr diff <N>` exactly as steps 1–5 describe, so the published copy matches the code that merged.
@@ -98,7 +100,7 @@ Run once, after `/review-pr` and any review fixes — normally just before merge
     - Inline the shared house style — copy its `<style>` block in place of the `<!-- HOUSE STYLE ... -->` marker in `<head>`, and its `<script>` block in place of the second marker before `</body>`. The output must be a single self-contained `.html` (no external assets).
     - Strip every instructional comment from the output (the head how-to block and the body notes). The artifact must be clean.
     - Fill the metadata tokens: `{{PROJECT}}`, `{{PR}}`, `{{PR_LINK}}` (Markdown link to the PR), `{{FEATURE}}` (short feature name), `{{BRANCH}}`, `{{COMMIT}}` (short SHA), `{{DATE}}`, `{{ESTIMATE}}`.
-    - Keep the production-verification callout in the HTML version too (it is part of the template). Convert the Markdown setup, logins, parts, not-browser-testable, and cleanup content into the HTML structure described inline in the template. Every command/credential/URL the tester will paste is a `<button type="button" class="copy" data-copy="VALUE">VALUE</button>` control.
+    - Keep the production-verification callout in the HTML version too (it is part of the template). Convert the Markdown setup, logins, parts, not-browser-testable, and cleanup content into the HTML structure described inline in the template. Every command/URL the tester will paste is a `<button type="button" class="copy" data-copy="VALUE">VALUE</button>` control, and so are reserved-example logins (see Credentials in published artifacts above) — login is the most repetitive step, so keep it click-to-copy. Only non-example/real credentials are the exception: render those as plain `<code>&lt;your-admin-email&gt;</code>`, not copy buttons.
     - Save to `tmp/pr-<N>-walkthrough-published.html`.
 6. **Build the PR-comment body** at `tmp/pr-<N>-walkthrough-comment.md`: a `<details>` block wrapping the Markdown twin so the link sits above and the Markdown is a collapsible fallback below.
 

--- a/claude/.claude/skills/walkthrough/template.html
+++ b/claude/.claude/skills/walkthrough/template.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<!--
+  Walkthrough structural template.
+
+  The /walkthrough skill fills this skeleton, then inlines the shared house
+  style so the output is a single self-contained, portable .html file.
+
+  How to use:
+  - Copy this whole document, then replace the {{TOKENS}} and the annotated
+    section regions with real content.
+  - Produce a CLEAN artifact: strip every instructional comment (this head
+    block and the explanatory notes in the body). They guide template-filling
+    only and must not appear in the output. (HTML comments do not nest, so a
+    stray instructional comment can also break rendering.)
+  - Inline the shared house style: copy the style block from
+    ../_shared/house-style.html into the head (replacing the HOUSE STYLE
+    marker) and its script block where the second HOUSE STYLE marker sits
+    (before the closing body tag). Do NOT link external assets.
+  - Make every command, credential, and URL the tester will paste a
+    click-to-copy control: a button with class "copy" and a data-copy value.
+  - When this is the post-merge/publish version, keep the production-verification
+    callout near the top; when it is the pre-review scratch copy, omit it.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{PROJECT}} — Walkthrough: PR #{{PR}}</title>
+<!-- HOUSE STYLE: inline the <style> block from ../_shared/house-style.html here -->
+</head>
+<body>
+<div class="wrap">
+
+  <nav class="toc">
+    <h2>Contents</h2>
+    <ol>
+      <li><a href="#setup">Setup</a></li>
+      <li><a href="#walkthrough">Walkthrough</a></li>
+      <li><a href="#not-browser-testable">Not browser-testable</a></li>
+      <li><a href="#cleanup">Cleanup</a></li>
+    </ol>
+  </nav>
+
+  <main>
+    <header class="doc">
+      <p class="eyebrow">{{PROJECT}} · PR Walkthrough</p>
+      <h1>PR #{{PR}}: {{FEATURE}}</h1>
+      <dl class="meta">
+        <dt>Project</dt><dd>{{PROJECT}}</dd>
+        <dt>PR</dt><dd>{{PR_LINK}}</dd>
+        <dt>Branch</dt><dd>{{BRANCH}}</dd>
+        <dt>Commit</dt><dd>{{COMMIT}}</dd>
+        <dt>Date</dt><dd>{{DATE}}</dd>
+        <dt>Estimate</dt><dd>~{{ESTIMATE}} minutes</dd>
+      </dl>
+    </header>
+
+    <!-- PRODUCTION VERIFICATION CALLOUT
+         Include this only when publishing the post-merge version. For a
+         pre-review scratch copy, remove the entire .callout block. -->
+    <div class="callout">
+      <span class="label">Verifying on production?</span>
+      Use the production app and your own account in place of the local server
+      and seed logins below. The steps and expected results are identical.
+    </div>
+
+    <details class="section" id="setup" open>
+      <summary>Setup</summary>
+      <div class="section-body">
+        <!-- Each command is a click-to-copy control, e.g.:
+             <button type="button" class="copy" data-copy="bin/dev">bin/dev</button>
+             Cover: start command + boot URL, migrations/deps/env vars/seed
+             reset (or "None"), locale/viewport notes if relevant. -->
+        {{SETUP}}
+
+        <h3>Logins</h3>
+        <!-- Replace with a table of test accounts. Each credential a .copy button:
+        <table>
+          <thead><tr><th>Role</th><th>Credentials</th><th>Notes</th></tr></thead>
+          <tbody>
+            <tr>
+              <td>admin <span class="role-pill">admin</span></td>
+              <td>
+                <button type="button" class="copy" data-copy="admin@example.com">admin@example.com</button>
+                /
+                <button type="button" class="copy" data-copy="password">password</button>
+              </td>
+              <td>full access</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>One literal sentence on how to log in (form / magic link / dev shortcut).</p>
+        -->
+        {{LOGINS}}
+      </div>
+    </details>
+
+    <details class="section" id="walkthrough" open>
+      <summary>Walkthrough</summary>
+      <div class="section-body">
+        <!-- One .story per Part. Label new-in-PR vs. pre-existing in the head.
+        <div class="story">
+          <div class="story-head">
+            Part 1 — Create a campaign
+            <span class="role-pill">new in this PR</span>
+          </div>
+          <div class="story-body">
+            <ol>
+              <li>Click <em>New campaign</em>.<br>
+                  <span class="expect">✅ Modal opens with empty form.</span></li>
+              <li>...</li>
+            </ol>
+          </div>
+        </div>
+        Use .role-pill for "new in this PR" / "pre-existing — for context". -->
+        {{PARTS}}
+      </div>
+    </details>
+
+    <details class="section" id="not-browser-testable">
+      <summary>Not browser-testable</summary>
+      <div class="section-body">
+        <!-- Bullet list of behaviors only covered by automated tests, with a
+             one-line reason each. Omit this section if everything is in-browser. -->
+        {{NOT_BROWSER_TESTABLE}}
+      </div>
+    </details>
+
+    <details class="section" id="cleanup">
+      <summary>Cleanup</summary>
+      <div class="section-body">
+        <!-- How to restore state after the walkthrough; whether the scratch
+             file is gitignored; anything else to tidy up. -->
+        {{CLEANUP}}
+      </div>
+    </details>
+
+    <footer class="doc">
+      Generated by the <code>/walkthrough</code> skill · {{DATE}}
+    </footer>
+  </main>
+</div>
+<!-- HOUSE STYLE: inline the <script> block from ../_shared/house-style.html here -->
+</body>
+</html>


### PR DESCRIPTION
## Summary

Completes Phase 1 of the HTML pivot for human-facing dev artifacts. `/walkthrough` and `/qa-handoff` now render rich, self-contained HTML that can be published to a per-project remote host so remote testers can open it from a URL — without losing the local-only-by-default contract for solo projects.

- New shared publish pipeline at `claude/.claude/skills/_shared/publish-artifact.sh` uses the GitHub Contents API to upload HTML to a project-declared target, handles the create-vs-update SHA dance, and posts a PR comment with the live Pages link.
- New `## QA Publish Target` convention: each project opts in by declaring `repo` + `subfolder` in its own `CLAUDE.md`. Absent or invalid → pipeline stays local and never guesses a target. Bootstrap template (`docs/prd-workflow/templates/CLAUDE.md`) ships the slot pre-wired.
- `/qa-handoff` was already converted to rich HTML earlier in the branch (PRs to that skill committed before this session); this PR adds `--publish` to it and wires both skills to the pipeline.
- New `walkthrough/template.html` mirroring `qa-handoff/template.html` for the rich HTML twin produced by `/walkthrough --publish`. The Markdown twin is still produced and remains the PR-comment fallback when no target is declared.
- `spec-driven-development.md` updated: §5 gains a "Medium: HTML vs. Markdown" subsection pairing format with the existing lifecycle split; §7 gains a "Publishing artifacts to remote testers" subsection and the skill table/PR-cycle captions reflect the new behaviour.

Per-project publishing remains opt-in. A solo project (e.g. a personal blog) simply omits the block and gets the pre-pivot local-only experience.

Also includes one unrelated chore commit (`d914e2c`) enabling the pyright-lsp plugin, picked up while the branch was open.

## Test plan

- [x] Pipeline smoke tests (Tier 1, run during development; the hardening fixes in `781bb67` and `97fea2f` came directly out of these):
  - [x] Missing `CLAUDE.md` → dies with clear message
  - [x] Section absent → warns, exits 0
  - [x] Placeholder values (`<owner>/<repo>`) → warns, exits 0
  - [x] Valid target, no `--pr` → uploads, prints Pages URL
  - [x] Valid target + `--pr` + `--comment-body` → posts PR comment with link + collapsible MD
  - [x] No target + `--pr` + `--md-fallback-only` → posts MD-only fallback comment
- [x] **End-to-end validated pre-merge against ComixDistro [#620](https://github.com/euroteamoutreach/comix_distro/pull/620)** (the test-run PR): `/walkthrough --publish` uploaded the HTML to GitHub Pages and posted the live link as a PR comment. Published page is live (HTTP 200): <https://euroteamoutreach.github.io/qa-walkthroughs/comixdistro/pr-620-walkthrough-published.html>. The credential-scoping rule (`77dfa62`) was surfaced and fixed during this run.
- [x] `/walkthrough --publish` on a project **without** a target falls back to the pre-pivot Markdown PR comment.
- [x] `/qa-handoff --publish` on a project without a target stays local and prints the warning.
- [x] shellcheck and markdownlint pass (run by pre-commit hooks on each commit — all green; shellcheck re-confirmed clean on `publish-artifact.sh` during review).

