### PR TITLE
feat(claude): make update-deps skill Dependabot-aware, security-auditing, and CI-validated

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Custom [skills][agent-skills] provide structured workflows for the full developm
 | `/setup-sprint` | Create parallel Git worktrees for a batch of labeled issues |
 | `/sprint-issue` | Streamlined variant for small, well-scoped issues |
 | `/todoist-cli` | Manage Todoist tasks, projects, and labels via the `td` CLI |
-| `/update-deps` | Safe dependency updates with testing between each category |
+| `/update-deps` | Dependabot-aware dependency updates with security audit, CI validation, and a unified PR |
 | `/walkthrough` | Generate a browser walkthrough of a PR's user-facing changes |
 
 ### Permission Presets

--- a/claude/.claude/docs/prd-workflow/spec-driven-development.md
+++ b/claude/.claude/docs/prd-workflow/spec-driven-development.md
@@ -283,7 +283,7 @@ This section maps every skill to its place in the development cycle. Think of it
 | `/qa-handoff` | Generate a hands-on QA testing guide as a self-contained HTML page; `--publish` uploads it to the project's QA host | Per feature (when needed) |
 | `/checkpoint` | Quick status check: where am I, what's next | Ad-hoc / returning from break |
 | `/debrief` | Detailed walkthrough of completed work | Phase boundary |
-| `/update-deps` | Update dependencies with testing between categories | Periodic maintenance |
+| `/update-deps` | Reconcile Dependabot PRs, audit security, validate on CI, open a unified PR | Periodic maintenance |
 | `/readme-refresh` | Audit and update README, or bootstrap one | Periodic / phase boundary |
 
 > **Note:** `/simplify` is a built-in Claude Code skill. All other entries listed above are custom skills defined in `~/.claude/skills/`.

--- a/claude/.claude/skills/update-deps/SKILL.md
+++ b/claude/.claude/skills/update-deps/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: update-deps
-description: Update project dependencies incrementally with testing between categories. Framework-agnostic.
+description: Dependabot-aware dependency updates with security audit, real-CI validation, and a unified PR. Framework-agnostic.
 disable-model-invocation: true
 ---
 
 # Update Dependencies
 
-Update project dependencies safely with testing between updates and documentation of breaking changes.
+Update project dependencies safely: reconcile open Dependabot PRs into one unified change, run the project's security audit, validate boot-affecting changes against the real CI environment, and open a single PR — instead of stopping at local commits.
+
+This skill is framework-agnostic. It **detects** the project's package manager, test/lint commands, audit suite, and CI workflow rather than assuming a stack.
 
 ## Command Options
 
@@ -15,179 +17,184 @@ Update project dependencies safely with testing between updates and documentatio
 - `--package <name>`: Update specific package only
 - `--skip-tests`: Skip running tests between updates
 
+## Workflow at a glance
+
+```text
+Detect → Reconcile Dependabot → Update → Audit → Validate on real CI → Open PR → Verify auto-close
+```
+
+Each stage feeds the next. Don't skip the audit or the real-CI validation for boot-affecting changes — those are the two stages that catch what local tests can't.
+
 ## Your task
 
-1. **Detect package manager**:
-   - Check for `package.json` (npm/yarn/pnpm)
-   - Check for `Gemfile` (bundler)
-   - Check for `requirements.txt` or `pyproject.toml` (pip/poetry)
-   - Check for `Cargo.toml` (cargo)
-   - Check for `go.mod` (go modules)
+### 1. Detect the environment (do not hardcode)
 
-2. **Analyze current dependencies**:
-   - List outdated packages with current and available versions
-   - Categorize updates: patch, minor, major
-   - Identify security-related updates (high priority)
+Detect both the package manager **and** the project's real entry points. The runners below are common defaults, not assumptions — always confirm against what the repo actually uses.
 
-3. **Plan update strategy**:
-   - Security updates first (always include)
-   - Patch updates (safe, low risk)
-   - Minor updates (moderate risk, new features)
-   - Major updates (high risk, breaking changes) - only if `--major` flag
+- **Package manager**:
+  - `package.json` (npm/yarn/pnpm) — check the lockfile to disambiguate
+  - `Gemfile` (bundler)
+  - `requirements.txt` / `pyproject.toml` (pip/poetry/uv)
+  - `Cargo.toml` (cargo)
+  - `go.mod` (go modules)
+- **Test/lint/CI entry points** — prefer a single project gate over assumed runners:
+  - A wrapper script like `bin/ci`, `bin/test`, `script/test`, or a `Makefile`/`Justfile` target is the **canonical gate** — use it if present.
+  - Otherwise detect the real tools: Minitest vs RSpec, StandardRB vs RuboCop, Herb, Biome vs ESLint, Prettier, `tsc`, `mypy`, etc.
+  - Detect the **CI workflow** itself: list `.github/workflows/*.yml` and identify the workflow that runs on the default branch and the jobs it contains.
+- **Audit suite** (see step 4) — detect, don't assume.
 
-4. **Execute updates incrementally**:
-   - Update one category at a time
-   - Run tests after each category
-   - **If `--skip-tests` provided**: Skip test execution
-   - Create separate commits for each category
-   - Stop and report if tests fail
+### 2. Reconcile open Dependabot PRs
 
-5. **Document changes**:
-   - Note any breaking changes in commit messages
-   - List significant new features or deprecations
-   - Record any configuration changes needed
+Before making any changes, find out what Dependabot already has in flight:
 
-6. **Handle test failures**:
-   - Identify which update caused the failure
-   - Offer to revert that specific update
-   - Suggest investigating the breaking change
-   - Continue with remaining updates if desired
+```bash
+gh pr list --app dependabot --state open --json number,title,headRefName,body
+```
 
-## Package Manager Commands
+- If open Dependabot PRs exist, **fold their bumps into one unified branch** rather than running in parallel and leaving stale PRs behind.
+- Land **the exact target versions or newer** for every bump a Dependabot PR covers. Dependabot **auto-closes** a PR once its target versions (or higher) land on the base branch — landing a lower version defeats that and leaves the PR open.
+- Note which PRs you expect to be superseded; you'll verify their auto-close in step 7.
+
+### 3. Update incrementally
+
+Keep the safe, category-by-category loop:
+
+- **Security updates first** (always include), then **patch**, then **minor**.
+- **Major updates** only with `--major`. Isolate a risky major into **its own commit — or its own PR** — so it can be rolled back cleanly without reverting the safe bumps.
+- Run the detected test gate after each category. **If `--skip-tests`**: skip test execution.
+- For major bumps, flag **soft-dependency and default-behavior changes** explicitly (a new transitive gem, a changed default `require:`, a renamed config key). These are where "the tests pass but boot breaks" lives.
+- Stop and report if the gate fails; offer to revert the specific update that caused it.
+
+### 4. Run the security audit
+
+This is the highest-value stage on a dependency PR — not an afterthought. After updates, run the project's detected audit suite and **fold any newly surfaced fix into this PR** (a fresh advisory is in-scope, not a separate task):
+
+| Ecosystem | Audit tools (detect what's present) |
+| --------- | ----------------------------------- |
+| Ruby | `bundler-audit`, `brakeman`, `importmap audit` |
+| Node | `npm audit`, `yarn npm audit`, `pnpm audit` |
+| Python | `pip-audit`, `safety` |
+| Rust | `cargo audit` |
+| Go | `govulncheck` |
+
+If the project's CI gate (e.g. `bin/ci`) already runs these, run that gate rather than invoking each tool separately.
+
+### 5. Validate boot-affecting changes on the real CI
+
+A change that touches the **manifest** (the `Gemfile`, `package.json`, `pyproject.toml` — not just the lockfile) can alter what loads at boot. Local gates **cannot** catch a failure caused by a system library that happens to be installed on the dev machine but missing on one CI job. Validate those changes on the actual CI environment before recommending merge:
+
+```bash
+gh workflow run <ci-workflow> --ref <branch>
+gh run watch   # or: gh run list --branch <branch>
+```
+
+Do this when:
+
+- The manifest changed (new dependency, changed `require:`/load behavior, version constraint change), **and/or**
+- A bump pulls in a native/system-backed library (image processing, crypto, database drivers).
+
+Lockfile-only patch bumps with a green local gate generally don't need a dedicated CI run.
+
+### 6. Open a unified PR
+
+Stop-at-commits is not the finish line. Open **one** PR for the reconciled set, following the project's PR conventions — hand off to the `/create-pr` skill (it generates the description, links issues, and updates the ROADMAP). Summarize in the PR body: the bumps grouped by category, the Dependabot PRs this supersedes, any CVE fixed, and the result of the real-CI run.
+
+### 7. Verify Dependabot auto-close (don't race it)
+
+After the PR merges, **expect** Dependabot to auto-close the superseded PRs on its own — verify it did rather than pre-emptively closing them:
+
+```bash
+gh pr list --app dependabot --state open
+```
+
+- If a superseded PR closed automatically: done.
+- **Fallback only:** if a PR is still open after Dependabot's next rebase cycle — the edge where a lower/different version landed and Dependabot just rebases instead of closing (see `dependabot/dependabot-core#13606`) — close it manually with a note. Don't duplicate Dependabot's behavior or race its rebase.
+
+## Design principles
+
+The lessons this workflow encodes, worth keeping in mind when a situation doesn't fit the steps above:
+
+- **"Passes locally, fails on one CI job" is a real failure class.** A local gate can't see a system library that's present on your machine but absent on a specific CI job. Boot-affecting dependency changes need real-CI validation, not just local tests.
+- **Don't fight Dependabot.** It already reconciles bumps and auto-closes superseded PRs. The skill's job is to *expect and verify* that behavior, not re-implement it.
+- **Security audits are the highest-value step**, not an afterthought. A plain update can ship a live CVE that only the audit catches.
+
+## Package manager commands
 
 ### npm/yarn/pnpm
 
 ```bash
-# Check outdated
-npm outdated
-yarn outdated
-pnpm outdated
-
-# Update specific package
-npm update <package>
-yarn upgrade <package>
-pnpm update <package>
+npm outdated        # check
+npm update <pkg>    # update
 ```
 
 ### Ruby (Bundler)
 
 ```bash
-# Check outdated
 bundle outdated
-
-# Update specific gem
 bundle update <gem>
 ```
 
 ### Python (pip/poetry)
 
 ```bash
-# Check outdated (pip)
 pip list --outdated
-
-# Update with poetry
-poetry show --outdated
-poetry update <package>
+poetry show --outdated && poetry update <pkg>
 ```
 
 ### Rust (Cargo)
 
 ```bash
-# Check outdated
 cargo outdated
-
-# Update dependencies
-cargo update <package>
+cargo update <pkg>
 ```
 
 ### Go
 
 ```bash
-# Check for updates
 go list -u -m all
-
-# Update dependencies
-go get -u <package>
+go get -u <pkg>
 ```
 
-## Update Categories
+## Update categories
 
-1. **Security Updates** (Always applied)
-   - Packages with known security vulnerabilities
-   - Critical security patches
+1. **Security updates** (always applied) — packages with known vulnerabilities.
+2. **Patch updates** (default) — bug fixes, e.g. `1.2.3 → 1.2.4`.
+3. **Minor updates** (default) — backwards-compatible features, e.g. `1.2.3 → 1.3.0`.
+4. **Major updates** (only with `--major`) — breaking changes, e.g. `1.2.3 → 2.0.0`. Isolate for clean rollback.
 
-2. **Patch Updates** (Applied by default)
-   - Bug fixes, security patches
-   - Version format: 1.2.3 → 1.2.4
+## Commit message format
 
-3. **Minor Updates** (Applied by default)
-   - New features, backwards compatible
-   - Version format: 1.2.3 → 1.3.0
-
-4. **Major Updates** (Only with --major flag)
-   - Breaking changes, API changes
-   - Version format: 1.2.3 → 2.0.0
-
-## Commit Message Format
-
-Use conventional commits format from global CLAUDE.md:
+Use Conventional Commits format from global CLAUDE.md:
 
 ```text
 chore(deps): update dependencies
 
 Security updates:
-- lodash: 4.17.19 → 4.17.21 (security fix)
+- erb: 6.0.1 → 6.0.3 (CVE-2026-41316)
 
 Patch updates:
-- react: 17.0.1 → 17.0.2
-- express: 4.17.1 → 4.17.3
+- rails: 7.1.3 → 7.1.5
 
 Minor updates:
-- typescript: 4.2.0 → 4.3.0 (new features)
-- eslint: 7.32.0 → 8.0.0
+- image_processing: 1.12 → 2.0
 
 Breaking changes:
-- Node.js 14+ now required for typescript 4.3+
+- image_processing 2.0 requires ruby-vips; added with require: false
+  so a missing libvips does not crash boot.
 ```
 
-## Example Workflow
-
-```bash
-# Detect: package.json found, using npm
-# Found 12 outdated packages:
-#   Security: lodash (4.17.19 → 4.17.21)
-#   Patch: react (17.0.1 → 17.0.2), express (4.17.1 → 4.17.3)
-#   Minor: typescript (4.2.0 → 4.3.0)
-#   Major: eslint (7.32.0 → 8.0.0) [requires --major flag]
-
-1. Update security packages → test → commit
-2. Update patch versions → test → commit
-3. Update minor versions → test → commit
-4. Suggest major updates for separate consideration
-```
-
-## Error Handling
+## Error handling
 
 - **No package manager detected**: "No supported package manager found"
-- **No outdated packages**: "All dependencies are up to date"
-- **Test failures**: Offer to revert problematic update
-- **Network issues**: Suggest retrying or checking connectivity
-- **Lock file conflicts**: Guide through resolution
+- **No outdated packages and no open Dependabot PRs**: "All dependencies are up to date"
+- **Test or audit failure**: identify the culprit update, offer to revert it
+- **Real-CI run fails**: report the failing job; do not recommend merge
+- **Lock file conflicts**: guide through resolution
 
-## Testing Integration
-
-After each update category:
-
-1. **Run existing test suite**: `npm test`, `bundle exec rspec`, etc.
-2. **Check build process**: `npm run build`, `cargo build`, etc.
-3. **Verify linting passes**: `npm run lint`, `rubocop`, etc.
-4. **Run type checking**: `tsc --noEmit`, `mypy`, etc.
-
-## Integration with Global Standards
+## Integration with global standards
 
 Follow dependency best practices from global CLAUDE.md:
 
-- Pin versions in production
-- Test breaking changes thoroughly
-- Document system requirements
-- Use lock files for consistent environments
+- Pin versions, use lock files for consistent environments
+- Test breaking changes thoroughly; document system requirements
+- Treat security advisories as in-scope for the dependency PR

--- a/claude/.claude/skills/update-deps/SKILL.md
+++ b/claude/.claude/skills/update-deps/SKILL.md
@@ -62,7 +62,7 @@ Keep the safe, category-by-category loop:
 - **Security updates first** (always include), then **patch**, then **minor**.
 - **Major updates** only with `--major`. Isolate a risky major into **its own commit — or its own PR** — so it can be rolled back cleanly without reverting the safe bumps.
 - Run the detected test gate after each category. **If `--skip-tests`**: skip test execution.
-- For major bumps, flag **soft-dependency and default-behavior changes** explicitly (a new transitive gem, a changed default `require:`, a renamed config key). These are where "the tests pass but boot breaks" lives.
+- For major bumps, flag **soft-dependency and default-behavior changes** explicitly — a newly pulled-in transitive dependency, a changed default load/eager-load behavior (e.g. Bundler's `require:`), a renamed config key. These are where "the tests pass but boot breaks" lives.
 - Stop and report if the gate fails; offer to revert the specific update that caused it.
 
 ### 4. Run the security audit
@@ -71,7 +71,7 @@ This is the highest-value stage on a dependency PR — not an afterthought. Afte
 
 | Ecosystem | Audit tools (detect what's present) |
 | --------- | ----------------------------------- |
-| Ruby | `bundler-audit`, `brakeman`, `importmap audit` |
+| Ruby | `bundler-audit`; plus `brakeman` and `importmap audit` on Rails |
 | Node | `npm audit`, `yarn npm audit`, `pnpm audit` |
 | Python | `pip-audit`, `safety` |
 | Rust | `cargo audit` |


### PR DESCRIPTION
## Summary

- Rewrites the `update-deps` skill from a generic, framework-agnostic updater into a **workflow-aware** tool: it reconciles open Dependabot PRs into one unified change, runs the project's security audit, validates boot-affecting changes against the real CI environment, and opens a single PR — instead of stopping at local commits.
- Encodes the lessons from a real end-to-end dependency-cleanup session (ComixDistro, 2026-05-31), including the failure class the old skill would have shipped: a `Gemfile`/boot-affecting change that passes locally but breaks one CI job because a system library is present on the dev machine and absent in CI.
- Stays framework-agnostic — every stage **detects** the project's package manager, test/lint/CI entry points, and audit suite rather than assuming a stack.

## Changes

**Skill rewrite** (`claude/.claude/skills/update-deps/SKILL.md`)

The `## Your task` section is now an ordered pipeline mapping 1:1 to the issue's acceptance criteria:

1. **Detect the environment (no hardcoding)** — package manager *and* the project's real test/lint/CI entry points (`bin/ci`, Minitest vs RSpec, StandardRB vs RuboCop, Herb, etc.) and CI workflow.
2. **Reconcile open Dependabot PRs** — `gh pr list --app dependabot`, fold the covered bumps into one branch, land the exact target versions or newer so auto-close fires cleanly.
3. **Update incrementally** — security → patch → minor; isolate a risky major into its own commit/PR; flag soft-dependency and default-behavior changes.
4. **Run the security audit** — per-ecosystem tooling (`bundler-audit`, `npm audit`, `pip-audit`, `cargo audit`, `govulncheck`); fold a newly surfaced advisory into the PR.
5. **Validate boot-affecting changes on the real CI** — for manifest changes, `gh workflow run <ci> --ref <branch>` before recommending merge.
6. **Open a unified PR** — hand off to `/create-pr` instead of stopping at commits.
7. **Verify Dependabot auto-close (don't race it)** — expect and verify auto-close; close manually only as a fallback.

Plus a new **Design principles** section encoding the three durable lessons ("passes locally, fails on one CI job" is a real failure class; don't fight Dependabot; security audits are the highest-value step). Command-line flags are unchanged.

**Doc sync** — updated the one-line `update-deps` descriptions in `README.md` (skills table) and `spec-driven-development.md` (skill map) to match the new scope.

## Testing

- [x] `./scripts/run-tests` — 72/72 pass
- [x] `./scripts/lint-shell` — 38 scripts pass
- [x] `markdownlint-cli2` — 0 errors (also green via pre-commit on every commit)
- [ ] **Manual follow-up (owner: Joshua):** exercise the skill against a real Dependabot batch (e.g. ComixDistro). This is the one acceptance-criterion item that can't be verified in the dotfiles repo — it needs a live repo with open Dependabot PRs.

## Notes

- This is a prose/skill deliverable — there's no automated test that exercises the skill's runtime behavior. Acceptance criteria 1–5 are satisfied at the spec level (the skill now instructs each behavior); the real proof is the manual Dependabot-batch run above. The issue's checkboxes are updated accordingly: 12 checked, with "tested against a real Dependabot batch" left unchecked pending that run.
- A `/simplify` pass ran before this PR. Reuse and efficiency were clean; two framework-agnostic altitude leaks were fixed (Ruby `require:` jargon generalized; `brakeman`/`importmap audit` marked Rails-specific in the audit table).

Closes #183
