### PR TITLE
feat(claude): add /prd-view skill to render PRD files as HTML reading views

### DIFF
--- a/claude/.claude/docs/prd-workflow/spec-driven-development.md
+++ b/claude/.claude/docs/prd-workflow/spec-driven-development.md
@@ -187,6 +187,8 @@ Document medium follows the same lifecycle split. Markdown for what an agent edi
 - **Markdown:** PRD files, ROADMAP, CHANGELOG, this handbook, skill instructions (SKILL.md), debrief summaries. Diffable, machine-readable, single source of truth.
 - **HTML:** debrief full reports, walkthroughs, QA handoffs, plans, mockups. Self-contained single files with click-to-copy controls, interactive checklists, and inline SVG. Opened in a browser with `open` — no build, no server.
 
+A third case sits between the two: a **derived reading view**. The canonical document stays Markdown — authoritative, diffable, the source of truth — while `/prd-view` *renders* a PRD file to a rich HTML Dashboard on demand (sidebar nav, an at-a-glance metric strip, collapsible cards, inline SVG). The HTML is ephemeral: generated to a gitignored `tmp/`, never committed, always regenerated from the current Markdown — so it cannot drift and never becomes a second source of truth. Its purpose is engagement *and* vetting — reading the rendered view surfaces gaps or errors, which are fixed in the Markdown and re-rendered. The spec earns its authority by being repeatedly engaged with, not skimmed once.
+
 The skills that produce HTML artifacts share a house style (`~/.claude/skills/_shared/house-style.html`) and a publish pipeline (see §7 "Publishing artifacts to remote testers") so the output is consistent and portable. The format that is easiest to maintain is not always the format that is most useful to read; the split keeps both honest.
 
 ---
@@ -269,6 +271,7 @@ This section maps every skill to its place in the development cycle. Think of it
 | Skill | Purpose | Cadence |
 | ------- | ------- | ------- |
 | `/bootstrap-prd` | Scaffold PRD structure for a new project | Once per project |
+| `/prd-view` | Render a PRD file as a rich HTML reading view (Dashboard style) for engaged reading and vetting; Markdown stays authoritative, the HTML is ephemeral | Ad-hoc (reading / vetting a spec) |
 | `/plan-phase` | Create GitHub issues from a PRD phase | Once per phase |
 | `/setup-sprint` | Create parallel worktrees for a batch of issues | Per sprint (optional) |
 | `/resolve-issue` | Implement an issue end-to-end; planning checkpoint scales to complexity | Per issue |

--- a/claude/.claude/skills/_shared/house-style.html
+++ b/claude/.claude/skills/_shared/house-style.html
@@ -34,6 +34,15 @@
   - Checklist:  ul.checklist > li > label > input[type=checkbox] — interactive
                 checkboxes the reader can tick.
   - Footer:     footer.doc.
+  - Metrics:    .metrics (grid) > .metric > .v (number) + .k (label) — the
+                at-a-glance summary strip under a doc header.
+  - Keyword:    .kw — RFC keyword chip (MUST/SHOULD/MAY) for spec text.
+  - TOC extras: nav.toc .crumb (breadcrumb), .ttl (doc title), a > .n (section
+                number), and .srcbox (the "source of truth" box).
+  - Section §:  details.section > summary .badge — a small right-aligned tag
+                (e.g. "§3") marking which source section a card renders.
+  - Fields:     in tables, .pill (type), .req (required marker), .opt (optional
+                / default marker) — for data-model field tables.
 
   The click-to-copy <script> below is the ONLY shared script. A skill that
   needs richer interactivity adds its own small vanilla <script> in its own
@@ -287,10 +296,31 @@
   ul.checklist label { display: flex; gap: 8px; align-items: flex-start; cursor: pointer; }
   ul.checklist input { margin-top: 5px; flex: none; }
   footer.doc { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--border); color: var(--muted); font-size: 13px; }
+  /* ---- Metric strip (at-a-glance summary under a doc header) ---- */
+  .metrics { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; margin: 18px 0 4px; }
+  .metric { border: 1px solid var(--border); border-radius: var(--radius); padding: 10px 12px; background: var(--surface); }
+  .metric .v { font-size: 21px; font-weight: 700; line-height: 1; }
+  .metric .k { font-size: 11px; color: var(--muted); margin-top: 5px; line-height: 1.3; }
+  /* ---- TOC extras: breadcrumb, doc title, section number, source-of-truth box ---- */
+  nav.toc .crumb { font-size: 11px; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase; color: var(--accent); margin: 0 0 4px; }
+  nav.toc .ttl { font-size: 16px; font-weight: 700; line-height: 1.25; margin: 0 0 16px; }
+  nav.toc a .n { color: var(--muted); font-variant-numeric: tabular-nums; margin-right: 4px; }
+  .srcbox { font-size: 12px; color: var(--muted); background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; margin-top: 14px; }
+  .srcbox b { color: var(--text); }
+  .srcbox code { font-family: var(--mono); font-size: 11.5px; }
+  /* ---- Section §N badge (right-aligned in a section summary) ---- */
+  details.section > summary .badge { margin-left: auto; font-family: var(--mono); font-size: 11px; font-weight: 600; color: var(--muted); background: var(--surface-2); border: 1px solid var(--border); border-radius: 999px; padding: 2px 9px; }
+  /* ---- RFC keyword chip (MUST / SHOULD / MAY) ---- */
+  .kw { font-family: var(--mono); font-size: 11px; font-weight: 700; letter-spacing: 0.04em; padding: 1px 7px; border-radius: 5px; background: color-mix(in srgb, var(--warn) 14%, var(--bg)); color: var(--warn); border: 1px solid color-mix(in srgb, var(--warn) 35%, transparent); }
+  /* ---- Data-model field markers (used inside tables) ---- */
+  .pill { font-family: var(--mono); font-size: 11px; padding: 1px 7px; border-radius: 999px; border: 1px solid var(--border); color: var(--muted); white-space: nowrap; }
+  .req { color: var(--bad); font-size: 11px; font-weight: 700; }
+  .opt { color: var(--muted); font-size: 11px; }
   /* ---- Responsive ---- */
   @media (max-width: 800px) {
     .wrap { grid-template-columns: 1fr; gap: 16px; padding: 20px 16px 64px; }
     nav.toc { position: static; max-height: none; border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 16px; background: var(--surface); }
+    .metrics { grid-template-columns: repeat(3, 1fr); }
   }
 </style>
 <script>

--- a/claude/.claude/skills/prd-view/SKILL.md
+++ b/claude/.claude/skills/prd-view/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: prd-view
+description: Render a PRD Markdown file as a rich, self-contained HTML reading view (Dashboard style) and open it in the browser. The Markdown stays authoritative; the HTML is a derived, ephemeral presentation.
+argument-hint: "[docs/prd/NN-feature.md]"
+---
+
+# PRD View
+
+Render one canonical PRD Markdown file as a rich **HTML reading view** — a sticky-sidebar "Dashboard" the human scans, jumps around, and collapses to fight overwhelm. The point is engagement: long monochrome specs go under-read, and an unread spec is not authoritative in practice.
+
+This view is **derived and ephemeral**. The Markdown file is the single source of truth. The HTML is a presentation generated on demand, written to a gitignored `tmp/` and never committed — so it cannot drift and there is never a second source of truth. It is also a **vetting instrument**: when the rendered view surfaces something wrong or surprising, the fix goes into the *Markdown*, and you regenerate — never patch the HTML.
+
+The cardinal rule follows from that: **present, do not embellish.** Every claim in the output must be traceable to the source file. Add no requirements, decisions, or structure the spec does not state. Diagrams encode only facts the spec gives. If the source is ambiguous or self-contradictory, *surface that* (a `callout.flag`) rather than silently resolving it — surfacing it is the vetting loop working.
+
+## Input
+
+- `$ARGUMENTS`: the path to one PRD Markdown file (e.g. `docs/prd/11-individual-book-requests.md`).
+- If no path is given, list the `docs/prd/*.md` files and ask which one to render. Render exactly one file per run (a whole-`docs/prd/` bundle is out of scope).
+
+## Your task
+
+### 1. Read and orient
+
+Read the target file in full. Identify the **project name** from the repo's `CLAUDE.md`, `docs/prd/README.md`, or repo name — it becomes the sidebar breadcrumb (e.g. "ComixDistro PRD"). Note the file's number and title for `{{DOC_TITLE}}` (e.g. "11 · Individual Book Requests").
+
+### 2. Understand the structure
+
+Map the file before rendering. Identify:
+
+- Its `##` sections (each becomes one collapsible card).
+- Tables — especially a **data-model** table (fields, types, required/optional).
+- Code/JSON blocks (keep as `<pre>`).
+- **Structural prose or ASCII** that wants to be a diagram: status/state lifecycles, architecture (services, hosting, data flow), sequences. These become inline SVG — **never** reproduce ASCII art.
+- **RFC keywords** (MUST / SHALL / SHOULD / MAY) — these are load-bearing; chip them.
+- **Cross-references** (`→ See file.md §N`) — keep them as explicit pointers back to the canonical Markdown.
+
+### 3. Choose the metric strip (4–6 cards)
+
+The at-a-glance strip is what gives confidence of completeness. Pick the **4–6 most salient counts for this specific file** — there is no fixed vocabulary. Good candidates, depending on the file:
+
+- lifecycle states · data models · fields · RFC `SHOULD`/`MUST` requirements · API endpoints · user roles/personas · channels/pools · phases · external integrations.
+
+Count honestly from the source. If a terse file has no meaningful counts, fall back to structural ones (sections, cross-refs) or omit the strip entirely rather than padding it with filler. Each card is `<div class="metric"><div class="v">N</div><div class="k">label</div></div>`.
+
+### 4. Render into the template
+
+The structure lives in `template.html` (this skill's directory); the look + click-to-copy live in `../_shared/house-style.html`. Produce the view by:
+
+1. **Read `template.html`** and use it as the exact structure. Its head comment documents every token and component snippet.
+2. **Inline the shared house style** — copy the `<style>` block from `../_shared/house-style.html` in place of the `<!-- HOUSE STYLE: … -->` marker, and its `<script>` block in place of the `<!-- HOUSE SCRIPT: … -->` marker. Copy the **actual `<style>…</style>` and `<script>…</script>` elements** (they begin at column 0): the file opens with a documentation comment that *mentions* `<style>`/`<script>` by name — do not capture that comment text or its closing `-->`, or you will nest the real CSS inside a broken element and lose all styling. Output must be one self-contained file — no external assets, no build step, works from `file://`.
+3. **Fill the tokens.** Build `{{TOC}}` (one `<li>` per section), `{{METRICS}}`, and `{{SECTIONS}}` (one `details.section` card per source `##` section, each with a `<span class="badge">§N</span>`). Open the high-signal early sections (context, architecture, model) by default; collapse deep-reference tails (exhaustive field lists, future considerations) so the page stays scannable.
+4. **Apply the conversions** as you fill each section:
+   - Data-model tables → keep the table, but mark types with `.pill` and required/optional with `.req` / `.opt`. Group or summarize a very long field list if it reads as a wall, but never drop fields silently — note any grouping.
+   - Lifecycle / architecture / sequence → inline `<svg>` inside `<figure class="diagram">`. The diagram must match the spec exactly (same states, same transitions, same components).
+   - RFC keywords → `<span class="kw">SHOULD</span>`.
+   - Pasteable values (endpoints, commands, seed values) → `<button class="copy" data-copy="VALUE">VALUE</button>`.
+   - Cross-refs → keep the `→ See file.md §N` pointer (a `<code>§N</code>` tag is fine) so the reader can reach the canonical detail.
+5. **Strip every instructional comment** — the template's head how-to block and all snippet comments guide filling only and must not appear in the output. *Keep* the template's interactive shell verbatim, though: its supplemental `<style>`/`<script>` and the back-to-top, expand/collapse-all, and click-to-copy source-path controls are real content, not instructional.
+
+### 5. Save and open
+
+Write to a stable, gitignored path inside the **project that owns the PRD** (reuse the same filename per source file, so re-runs just need a browser refresh):
+
+```text
+tmp/prd-view/<source-file-basename>.html
+```
+
+Then open it so the reader doesn't have to — it is a single self-contained file, so this is instant and needs no server:
+
+```bash
+open tmp/prd-view/<source-file-basename>.html
+```
+
+`open` uses the default browser; pin one if the Clipboard API needs it: `open -a "Google Chrome" <file>`.
+
+### 6. Report and invite the vetting loop
+
+Tell the reader the path and that it was opened, then explicitly invite the loop:
+
+```text
+View:   tmp/prd-view/11-individual-book-requests.html  (opened in your browser)
+Source: docs/prd/11-individual-book-requests.md  (authoritative)
+```
+
+Close by inviting correction: if anything in the view looks wrong, thin, or surprising, we fix the **Markdown** and regenerate. That round-trip is the feature.
+
+## Important
+
+- **Local-only.** This view is for the author, like `/debrief`. No publishing, no hosting, no PR comments.
+- **Ephemeral.** Output lives in gitignored `tmp/` and is regenerated on demand — never commit it, never treat it as a source.
+- **One file in, one view out.** No whole-`docs/prd/` bundle, no cross-file navigation — that is deferred.
+- **Faithful, not creative.** When in doubt about a diagram or a count, prefer the simplest correct rendering or omit it. Surfacing a gap beats inventing a detail.

--- a/claude/.claude/skills/prd-view/template.html
+++ b/claude/.claude/skills/prd-view/template.html
@@ -1,0 +1,131 @@
+<!--
+  /prd-view DASHBOARD TEMPLATE — structure only. The look + click-to-copy come
+  from ../_shared/house-style.html (inlined at build time). Fill the tokens,
+  inline the house style, and STRIP every instructional comment (including this
+  block and the example snippets) from the final output. HTML comments do not
+  nest, so a leftover instructional comment can break rendering.
+
+  This view is a DERIVED, EPHEMERAL presentation of an authoritative PRD
+  Markdown file. Render what the source says — present, do not embellish. Every
+  claim must be traceable to the source file; diagrams encode only stated facts.
+
+  KEEP the interactive shell verbatim — it is real content, not instructional:
+    - the supplemental <style> block (skill-local interactive chrome)
+    - the supplemental <script> block (expand/collapse-all + back-to-top)
+    - the <a class="crumb" href="#top">, the .toc-actions controls,
+      the #toTop button, and the click-to-copy source path.
+
+  TOKENS (single source value, used in head + sidebar + header + footer):
+    {{PRD_NAME}}     Project + doc family, e.g. "ComixDistro PRD"
+    {{DOC_TITLE}}    File number + title, e.g. "11 · Individual Book Requests"
+    {{TITLE}}        The H1, e.g. "Individual Book Requests"
+    {{SUBTITLE}}     One-line description (the source's opening sentence, trimmed)
+    {{STATUS_LINE}}  Eyebrow, e.g. "Feature spec · Status: Specified"
+    {{SOURCE_PATH}}  Repo-relative path, e.g. "docs/prd/11-individual-book-requests.md"
+    {{TOC}}          One <li> per rendered section (see snippet)
+    {{METRICS}}      4–6 .metric cards of the most salient counts (see snippet)
+    {{SECTIONS}}     One details.section card per source "##" section (see snippet)
+
+  COMPONENT SNIPPETS (copy, fill, repeat — then delete the snippet comments):
+
+    TOC entry:
+      <li><a href="#s3"><span class="n">3</span> BookRequest model</a></li>
+
+    Metric card (pick the counts that matter for THIS file):
+      <div class="metric"><div class="v">5</div><div class="k">lifecycle states</div></div>
+
+    Section card (open the high-value ones; add the §N badge):
+      <details class="section" id="s3" open>
+        <summary>3 · BookRequest model <span class="badge">§3</span></summary>
+        <div class="section-body"> ...rendered section content... </div>
+      </details>
+
+    RFC keyword inline:  <span class="kw">SHOULD</span>
+    Callout (info / .warn / .flag): <div class="callout"><span class="label">…</span>…</div>
+    Data-model table cell markers: <span class="pill">string</span> · <span class="req">required</span> · <span class="opt">optional</span>
+    Cross-ref pointer back to canonical MD: keep "→ See file.md §N" as text or a <code>§N</code> tag.
+    Diagram (NEVER ASCII): <figure class="diagram"><svg …>…</svg><figcaption>…</figcaption></figure>
+    Click-to-copy a pasteable value: <button class="copy" data-copy="VALUE">VALUE</button>
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{TITLE}} — {{PRD_NAME}}</title>
+<!-- HOUSE STYLE: replace this marker with the <style> block from ../_shared/house-style.html -->
+<style>
+  /* /prd-view interactive chrome — skill-local (the shared house style is visual only). */
+  nav.toc a.crumb { text-decoration: none; cursor: pointer; display: inline-block; }
+  nav.toc a.crumb:hover { text-decoration: underline; }
+  .toc-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; flex-wrap: wrap; }
+  .toc-actions { font-size: 11px; white-space: nowrap; color: var(--muted); }
+  .lnk { background: none; border: 0; padding: 0; margin: 0; color: var(--accent); font: inherit; font-size: 11px; cursor: pointer; }
+  .lnk:hover { text-decoration: underline; }
+  .to-top {
+    position: fixed; right: 20px; bottom: 20px; z-index: 20;
+    display: inline-flex; align-items: center; gap: 5px;
+    background: var(--accent); color: #fff; border: 1px solid var(--accent); border-radius: 999px;
+    padding: 8px 14px; font: 600 13px var(--sans); cursor: pointer;
+    opacity: 0; transform: translateY(8px); pointer-events: none;
+    transition: opacity .15s ease, transform .15s ease; box-shadow: 0 2px 8px rgba(0,0,0,.18);
+  }
+  .to-top.show { opacity: 1; transform: none; pointer-events: auto; }
+  .to-top:hover { filter: brightness(1.08); }
+</style>
+</head>
+<body>
+<div class="wrap" id="top">
+
+  <nav class="toc">
+    <a class="crumb" href="#top">{{PRD_NAME}}</a>
+    <p class="ttl">{{DOC_TITLE}}</p>
+    <div class="toc-head">
+      <h2>On this page</h2>
+      <span class="toc-actions"><button type="button" class="lnk" data-sections="open">Expand all</button> · <button type="button" class="lnk" data-sections="close">Collapse all</button></span>
+    </div>
+    <ol>
+      {{TOC}}
+    </ol>
+    <div class="srcbox"><b>Source of truth</b><br>Generated from <button class="copy" data-copy="{{SOURCE_PATH}}">{{SOURCE_PATH}}</button> — click to copy the path, then open it in your editor. Edit the Markdown; never this page.</div>
+  </nav>
+
+  <main>
+    <header class="doc">
+      <p class="eyebrow">{{STATUS_LINE}}</p>
+      <h1>{{TITLE}}</h1>
+      <p class="sub">{{SUBTITLE}}</p>
+      <div class="metrics">
+        {{METRICS}}
+      </div>
+    </header>
+
+    {{SECTIONS}}
+
+    <footer class="doc">Generated reading view of <code>{{SOURCE_PATH}}</code> — the authoritative source. Every claim here is drawn from that file: presented, not embellished. Regenerate after any edit to the Markdown.</footer>
+  </main>
+</div>
+
+<button type="button" id="toTop" class="to-top" aria-label="Back to top" title="Back to top">↑ Top</button>
+
+<!-- HOUSE SCRIPT: replace this marker with the <script> block from ../_shared/house-style.html -->
+<script>
+  // Skill-local interactivity: expand/collapse all sections + back-to-top.
+  (function () {
+    document.addEventListener("click", function (e) {
+      var b = e.target.closest("[data-sections]");
+      if (!b) return;
+      var open = b.getAttribute("data-sections") === "open";
+      document.querySelectorAll("details.section").forEach(function (d) { d.open = open; });
+    });
+    var btn = document.getElementById("toTop");
+    if (btn) {
+      var toggle = function () { btn.classList.toggle("show", window.scrollY > 400); };
+      window.addEventListener("scroll", toggle, { passive: true });
+      toggle();
+      btn.addEventListener("click", function () { window.scrollTo({ top: 0, behavior: "smooth" }); });
+    }
+  })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What & why

Phase 2 of the HTML pivot. Adds **`/prd-view`** — a skill that renders a single canonical PRD Markdown file as a rich, self-contained **HTML "Dashboard" reading view** and opens it in the browser.

The Markdown stays the **source of truth**; the HTML is a **derived, ephemeral presentation** (written to a gitignored `tmp/`, regenerated on demand, never committed — so it cannot drift and never becomes a second source). Beyond engagement, the view is a **vetting instrument**: reading the rendered spec surfaces gaps or errors, which get fixed in the *Markdown* and re-rendered. The spec earns its authority by being repeatedly engaged with, not skimmed once.

Mechanism is **model-authored + ephemeral** (a pure `pandoc` pass can't produce the metric strip, SVG diagrams, or keyword chips that make the view work).

## What's in it

- **New skill** `claude/.claude/skills/prd-view/`:
  - `SKILL.md` — read a PRD file → Dashboard HTML → `tmp/` → `open`; model-chosen metric strip; the **"rich, not embellished"** discipline (every claim traceable to the source; surface ambiguity rather than resolve it).
  - `template.html` — Dashboard shell with house-style markers, fill tokens, documented component snippets, and the interactive shell.
- **`_shared/house-style.html`** — purely additive Dashboard vocabulary (metric strip, RFC keyword chips, section `§N` badge, source-of-truth box, field markers, TOC extras). Existing `/debrief` · `/walkthrough` · `/qa-handoff` output is unaffected.
- **Interactive shell** (in the template, per the convention that the shared partial is visual-only): back-to-top, expand/collapse-all, click-to-copy source path.
- **Docs** — `spec-driven-development.md` gains a "derived reading view" paragraph in §5 and a `/prd-view` skill-table row.

## Validation

Rendered against ComixDistro `docs/prd/` through the real template + house style:

- **Feature 11** (rich — 9 sections, 24-field data model, 5-state lifecycle): 9 cards, 6-card metric strip, 2 inline SVGs.
- **Feature 03** (terse — 5 sections, no data model): 5 cards, 4-card metric strip (scales down, not padded), 1 SVG.

Generalizes across file shapes. Output is single-file, self-contained, dark-mode aware, works from `file://`. The generated views are ephemeral (ComixDistro `tmp/`) and not part of this PR.

Closes #191
