### PR TITLE
feat(claude): let /qa-handoff serve static/Hugo sites

### DIFF
--- a/claude/.claude/skills/qa-handoff/SKILL.md
+++ b/claude/.claude/skills/qa-handoff/SKILL.md
@@ -25,7 +25,7 @@ Both paths produce the same kind of artifact — a single self-contained HTML pa
 
 **Rails path also:** Read `db/seeds.rb` to identify test accounts and credentials (reference them exactly). Review the `Gemfile` and recent migrations for setup the tester needs.
 
-**Static-site path also:** Identify the **deploy-preview URL** the tester should open — a Netlify deploy preview is the typical source; if it isn't obvious from `CLAUDE.md` or the repo, ask the user. Note the local preview command (`hugo server`). Check for a redirects file or redirect map (`static/_redirects`, `netlify.toml`, or a documented map) — if one exists, pull specific old→new URLs to list as redirects to verify. Note whether the deploy preview is access-gated.
+**Static-site path also:** Identify the **deploy-preview URL** the tester should open — a Netlify deploy preview is the typical source; if it isn't obvious from `CLAUDE.md` or the repo, ask the user. Note the local preview command (`hugo server`) and whether the preview is access-gated. Check the Hugo config for **multiple languages** (`languages` / `defaultContentLanguage`, an `i18n/` dir, or `content/<lang>/`) — if multilingual, include the Languages & Translations section. Identify **forms and external integrations** and their backends (Netlify Forms, an external API, a separate app), and note any restricted to certain domains (e.g. a CORS allowlist) so the guide can tell testers which environment to use. For URL continuity, remember Hugo migrations often preserve old paths by slug-matching rather than redirect maps — check both that preserved URLs still resolve and that removed URLs are intentionally gone.
 
 ## Output Format
 
@@ -38,7 +38,7 @@ Render the handoff as a single self-contained **HTML** page using the shared hou
 
 1. **Read your mode's template** (this skill's directory) for the structure and `../_shared/house-style.html` for the look. The template's head comment documents every token.
 2. **Inline the shared house style** — copy its `<style>` block in place of the `<!-- HOUSE STYLE ... -->` marker in `<head>`, and its `<script>` block in place of the second marker before `</body>`. The output must be a single self-contained `.html` (no external assets). Do not link a stylesheet.
-3. **Strip every instructional comment** from the output (the head how-to block and the body notes). The artifact must be clean. (HTML comments do not nest, so a leftover one can break rendering, not just clutter it.) *Static template only:* if the site has no giving/commerce/signup flows, also delete the optional **Donation Paths** section and its TOC entry.
+3. **Strip every instructional comment** from the output (the head how-to block and the body notes). The artifact must be clean. (HTML comments do not nest, so a leftover one can break rendering, not just clutter it.) *Static template only:* delete any optional section that doesn't apply — the **Languages & Translations** section for a single-language site, and the **Key Flows & Forms** section for a purely informational site — along with its TOC entry.
 4. **Resolve the QA report URL (`{{REPORT_URL}}`).** Find the project's GitHub repo via `gh repo view --json nameWithOwner --jq .nameWithOwner`. Look in `.github/ISSUE_TEMPLATE/` for a QA template (filename matching `qa`, case-insensitive — prefer YAML issue forms over plain Markdown). Build the URL:
     - **QA template found:** `https://github.com/<owner>/<repo>/issues/new?template=<filename>`. Leave the title blank so the template's own placeholder guides the tester.
     - **No QA template:** `https://github.com/<owner>/<repo>/issues/new`.
@@ -70,21 +70,28 @@ Fill each token with the content below. The checklist sections use an interactiv
 
 **What's New (`{{WHATS_NEW}}`)** — a plain-language summary of what changed on the site (new or updated pages, redesigns, migrated content). 2–4 short paragraphs connecting to the goal. No jargon.
 
-**Where to Test (`{{WHERE}}`)** — the **deploy-preview URL** as a copy control (a Netlify deploy preview is typical). Add the local option for testers who clone: `git pull`, then `hugo server`, and the localhost URL — each a copy control. If the preview is access-gated, add a one-line preview-access note (placeholder only — see Credentials).
+**Where to Test (`{{WHERE}}`)** — the **deploy-preview URL** as a copy control (a Netlify deploy preview is typical). Add the local option for testers who clone: `git pull`, then `hugo server`, and the localhost URL — each a copy control. If the preview is access-gated, add a one-line preview-access note (placeholder only — see Credentials). **Call out environment limits:** some checks cannot be done on a per-PR deploy preview — an external API with a CORS allowlist, or form-email notifications that only fire in production. For each, say which environment it must be done in (per-PR preview vs. branch deploy vs. production) so testers don't file false "broken form" reports.
 
 **Guided Walkthrough (`{{WALKTHROUGH}}`)** — one `<div class="story">` per key page or flow, in reading order. The `.role-pill` is the visitor type (Visitor / Donor / Mobile visitor). Give a copyable starting URL (preview URL + path), literal numbered steps, and a `.expect` result. Cover the new/changed pages; add a mobile scenario per any `CLAUDE.md` viewport guidance.
 
-**Content & Links (`{{CONTENT}}`)** — checklist: copy accuracy (no lorem/placeholder; names, dates, figures, and contact info correct); every nav/footer/CTA link resolves; **old→new redirects resolve with no 404s** — when a redirect map/file exists, list the specific old URLs to verify; navigation works (menu, breadcrumbs, footer).
+**Content & Links (`{{CONTENT}}`)** — checklist: copy accuracy (no lorem/placeholder; names, dates, figures, and contact info correct); every nav/footer/CTA link resolves; navigation works (menu, breadcrumbs, footer). **URL continuity from the old site:** Hugo migrations often preserve URLs by slug-matching rather than redirect maps, so check both directions — (a) every preserved old URL still resolves at the same path, and (b) every *removed* old URL is intentionally gone (redirect it if it was indexed/linked, or accept the 404).
 
-**Donation Paths (`{{DONATION}}`) — optional** — include for giving/commerce/signup sites; delete the section and its TOC entry otherwise. Highest-stakes for a donor-facing site: exercise each give route end to end (mail-a-check address correct; PayPal link works and lands on the right account; any new platform flow completes), plus related form submissions (contact, newsletter) and their confirmations.
+**Languages & Translations (`{{I18N}}`) — optional** — include only for multilingual sites; delete the section and its TOC entry for a single-language site. Checklist: the language switcher works and appears only where a translation actually exists (not on single-language pages); each language's URLs resolve (e.g. `/` and `/en/...`) and routes with no translation 404 intentionally rather than rendering a broken page; **hreflang tags are present** linking the language variants; translated pages show the target language throughout (no silent fallback to the default language); language-specific metadata (`og:locale`) is correct.
 
-**Responsive & Visual (`{{RESPONSIVE}}`)** — checklist: mobile/tablet/desktop layouts; images load and aren't distorted; logos, brand colors, and favicon render; no horizontal overflow; text readable; nav collapses correctly on small screens.
+**Key Flows & Forms (`{{FLOWS}}`) — optional** — include for sites with conversion/action paths; delete the section and its TOC entry for a purely informational site. Exercise the site's primary actions end to end as a checklist:
+
+- **Donations** (when present — first-class for donor-giving sites): each give route works (mail-a-check address correct; PayPal link lands on the right account; any new platform flow completes).
+- **Forms by backend:** list each form with its backend, *where it can actually be tested* (see Where to Test), and its success UX (often an inline message rather than a redirect). Verify each confirmation.
+- **External-app handoffs:** links/CTAs that hand off to a separate app or domain land correctly.
+- **Disabled/empty states:** if a form or flow can be toggled off (out-of-stock, closed), the off state replaces it cleanly.
+
+**Responsive & Visual (`{{RESPONSIVE}}`)** — checklist: mobile/tablet/desktop layouts; images load and aren't distorted; logos, brand colors, favicon, and any PWA manifest render; no horizontal overflow; text readable; nav collapses correctly on small screens; **no flash-of-unstyled-content (FOUC)** on load, especially for sticky or scroll-reactive headers.
 
 **Meta & Sharing (`{{META}}`)** — checklist: page titles and meta descriptions present and accurate; social share cards (`og:image`, `og:title`, `twitter:*`) render when a page is shared; canonical URLs correct.
 
-**Accessibility (`{{A11Y}}`)** — checklist: images have meaningful alt text; color contrast is sufficient; keyboard navigation reaches all interactive elements with a visible focus state; heading order is logical. Spot checks, not an exhaustive audit.
+**Accessibility (`{{A11Y}}`)** — checklist: images have meaningful alt text **in the site's language(s)**; color contrast is sufficient; keyboard navigation reaches all interactive elements with a visible focus state; heading order is logical. Spot checks, not an exhaustive audit.
 
-**Build & Health (`{{BUILD}}`)** — commands as copy controls: a clean production build (`hugo --gc --minify`) with no errors or warnings. Note checks to do on the preview: no browser console errors; no mixed-content (all assets over https). Actual broken-link crawling is out of scope for this skill — the Content & Links checklist covers links by hand.
+**Build & Health (`{{BUILD}}`)** — commands as copy controls: a clean production build (`hugo --gc --minify`) with no errors or warnings. **A green build is not enough** — also verify: interactive JS still works *after* minification (tree-shaking can silently drop handlers a dev build kept, shipping a clean build with broken forms); the pinned Hugo version matches across deploy config and CI (`netlify.toml`, `.github/workflows/`); on the preview, no browser console errors and no mixed-content (all https). Actual broken-link crawling stays out of scope — Content & Links covers links by hand.
 
 **Feedback** — built into the template: a CTA button linking to the QA issue form via `{{REPORT_URL}}`. Do not reconstruct the form.
 

--- a/claude/.claude/skills/qa-handoff/SKILL.md
+++ b/claude/.claude/skills/qa-handoff/SKILL.md
@@ -1,59 +1,92 @@
 ---
 name: qa-handoff
-description: Generate a hands-on QA testing guide with walkthrough scenarios and exploratory testing checklist. --publish uploads the HTML to the project's configured QA host.
+description: Generate a hands-on QA testing guide as a self-contained HTML page — for Rails apps or static (Hugo) sites. --publish uploads the HTML to the project's configured QA host.
 disable-model-invocation: true
 argument-hint: "[--publish] [--pr <N>]"
 ---
 
 # QA Handoff
 
-**Applicability:** This command is designed for Rails applications that follow a PRD-driven development workflow with `docs/prd/ROADMAP.md` and a debriefs structure under `docs/debriefs/`. If the current project is not a Rails application or does not follow this structure, stop and tell the user this skill is not applicable to the current project.
+You are a senior developer preparing a hands-on testing guide for a QA colleague. Your colleague understands the product but is NOT tracking implementation details, architecture decisions, or code-level rationale. Write for someone who needs a clear, step-by-step guide to exercise the new work and find gaps in behavior and UX.
 
----
+## Step 0: Detect the project type
 
-You are a senior developer preparing a hands-on testing guide for a QA colleague. Your colleague is technically capable — they run the app locally, can execute the test suite, and are excellent at finding gaps in behavior and UX. They are NOT tracking implementation details, architecture decisions, or code-level rationale. Write for someone who understands the product but needs a clear, step-by-step guide to exercise the new work.
+Pick the mode from what's in the repo:
+
+- **Rails app** — a `Gemfile` plus `config/application.rb` or `bin/rails`. Follow the **Rails path** (template `template.html`).
+- **Static site (Hugo)** — a Hugo config (`hugo.toml` / `hugo.yaml` / `hugo.json`, or `config.toml` / `config/_default/`) with a `content/` directory (or another static-site generator). Follow the **Static-site path** (template `template-static.html`).
+- **Neither** — tell the user this skill targets Rails apps and static sites, and stop.
+
+Both paths produce the same kind of artifact — a single self-contained HTML page built from the shared house style and shipped through the shared publish pipeline. They differ only in which template and section content they use.
 
 ## Context
 
-1. Read the project's `CLAUDE.md` and `docs/prd/ROADMAP.md` to orient yourself. Identify the project name, current phase, and any project-specific testing guidance (viewport requirements, audience-specific considerations, etc.).
-2. Check `docs/debriefs/full/` for the most recent debrief. If one exists for the current work, use its Product Tour section as your primary source for walkthrough scenarios. Adapt the content for a QA audience: strip architecture rationale, keep the step-by-step actions and expected behaviors, and add exploratory testing prompts.
-3. If no recent debrief exists, build the walkthrough from scratch by reviewing recent git history, seed data, routes, and controllers.
-4. Read `db/seeds.rb` to identify available test accounts and their credentials. Reference these exactly in the walkthrough scenarios.
-5. Review the Gemfile and recent migrations for any setup changes the tester needs to know about.
+**Both paths:** Read the project's `CLAUDE.md` (project name, any audience/viewport guidance, the `## QA Publish Target` block) and `docs/prd/ROADMAP.md` if present (current phase). Check `docs/debriefs/full/` for the most recent debrief; if one covers the current work, reuse its Product Tour as the basis for the walkthrough (strip rationale, keep the actions and expected behaviors). Otherwise build the walkthrough from recent git history.
+
+**Rails path also:** Read `db/seeds.rb` to identify test accounts and credentials (reference them exactly). Review the `Gemfile` and recent migrations for setup the tester needs.
+
+**Static-site path also:** Identify the **deploy-preview URL** the tester should open — a Netlify deploy preview is the typical source; if it isn't obvious from `CLAUDE.md` or the repo, ask the user. Note the local preview command (`hugo server`). Check for a redirects file or redirect map (`static/_redirects`, `netlify.toml`, or a documented map) — if one exists, pull specific old→new URLs to list as redirects to verify. Note whether the deploy preview is access-gated.
 
 ## Output Format
 
-Render the handoff as a single self-contained **HTML** page using this skill's `template.html` and the shared house style — not a Markdown document. The tester opens it in a browser and gets click-to-copy logins, an interactive exploratory checklist, and a one-click link to the project's existing QA issue form for reporting findings.
+Render the handoff as a single self-contained **HTML** page using the shared house style — not a Markdown document. Use the template for your mode:
+
+- **Rails:** `template.html`
+- **Static site:** `template-static.html`
 
 ### Rendering
 
-1. **Read `template.html`** (this skill's directory) for the structure and `../_shared/house-style.html` for the look. The template's head comment documents every token.
+1. **Read your mode's template** (this skill's directory) for the structure and `../_shared/house-style.html` for the look. The template's head comment documents every token.
 2. **Inline the shared house style** — copy its `<style>` block in place of the `<!-- HOUSE STYLE ... -->` marker in `<head>`, and its `<script>` block in place of the second marker before `</body>`. The output must be a single self-contained `.html` (no external assets). Do not link a stylesheet.
-3. **Strip every instructional comment** from the output (the head how-to block and the body notes). The artifact must be clean. (HTML comments do not nest, so a leftover one can break rendering, not just clutter it.)
+3. **Strip every instructional comment** from the output (the head how-to block and the body notes). The artifact must be clean. (HTML comments do not nest, so a leftover one can break rendering, not just clutter it.) *Static template only:* if the site has no giving/commerce/signup flows, also delete the optional **Donation Paths** section and its TOC entry.
 4. **Resolve the QA report URL (`{{REPORT_URL}}`).** Find the project's GitHub repo via `gh repo view --json nameWithOwner --jq .nameWithOwner`. Look in `.github/ISSUE_TEMPLATE/` for a QA template (filename matching `qa`, case-insensitive — prefer YAML issue forms over plain Markdown). Build the URL:
-    - **QA template found:** `https://github.com/<owner>/<repo>/issues/new?template=<filename>`. Leave the title blank so the template's own `QA: <short description>` placeholder guides the tester.
+    - **QA template found:** `https://github.com/<owner>/<repo>/issues/new?template=<filename>`. Leave the title blank so the template's own placeholder guides the tester.
     - **No QA template:** `https://github.com/<owner>/<repo>/issues/new`.
     - **No GitHub remote:** omit the CTA. Replace the Feedback section's button paragraph with a one-line note pointing at the project's actual tracker.
-5. **Fill the metadata tokens:** `{{PROJECT}}`, `{{TITLE}}` (e.g. `Phase N: Phase Title`), `{{DATE}}`, `{{BRANCH}}`, `{{COMMIT}}` (short SHA from `HEAD`), `{{DEBRIEF_REF}}` (path to the related debrief, or `N/A`), `{{REPORT_URL}}` (from step 4).
+5. **Fill the metadata tokens:** `{{PROJECT}}`, `{{TITLE}}` (e.g. `Phase N: Phase Title`), `{{DATE}}`, `{{BRANCH}}`, `{{COMMIT}}` (short SHA from `HEAD`), `{{REPORT_URL}}` (step 4); then the mode-specific one — Rails: `{{DEBRIEF_REF}}` (path to the related debrief, or `N/A`); static: `{{PREVIEW_URL}}` (the deploy-preview URL).
 6. **Make every real command and URL the tester will paste a click-to-copy control:** `<button type="button" class="copy" data-copy="VALUE">VALUE</button>`.
 
-**Credentials.** The handoff HTML is a single file that is both committed and (with `--publish`) uploaded to a public QA host. A login may be a click-to-copy control only when it is a *reserved, non-routable example identity*: an RFC 2606 reserved domain (`example.com`/`.net`/`.org`) or the `.example` TLD, with any password an obviously-fake seed value (e.g. `password`). Such fakes are documentation, not credentials — and login is the most repetitive step, so keep them click-to-copy. Any real or real-looking login (real domain, actual person, live tenant, real password/token) must be a plain placeholder (`<code>&lt;your-admin-email&gt;</code>`), never a copy control; add a one-line note (local: seeded logins from `db/seeds.rb`; production: your own account). Never publish a real secret in any form.
+**Credentials.** The handoff HTML is a single file that is both committed and (with `--publish`) uploaded to a public QA host. A login may be a click-to-copy control only when it is a *reserved, non-routable example identity*: an RFC 2606 reserved domain (`example.com`/`.net`/`.org`) or the `.example` TLD, with any password an obviously-fake seed value (e.g. `password`). Such fakes are documentation, not credentials. Any real or real-looking login (real domain, actual person, live tenant, real password/token) must be a plain placeholder (`<code>&lt;your-admin-email&gt;</code>`), never a copy control; add a one-line note (Rails local: seeded logins from `db/seeds.rb`; production: your own account). **Static sites** usually have no logins at all — but if the deploy preview is password-gated, treat that access the same way: a placeholder plus a one-line note, never a real secret. Never publish a real secret in any form.
 
-### Section content
+### Section content — Rails path
 
-Fill each section token with the content described below.
+Fill each token with the content below.
 
-**What's New (`{{WHATS_NEW}}`)** — a plain-language summary of what was built, for someone who understands the product but isn't tracking implementation details. 2-4 short paragraphs; connect to the roadmap. No file paths, class names, or architecture jargon.
+**What's New (`{{WHATS_NEW}}`)** — a plain-language summary of what was built. 2–4 short paragraphs; connect to the roadmap. No file paths, class names, or architecture jargon.
 
 **Getting Current (`{{SETUP}}`)** — exact setup steps, each command a copy control: pull/install (`git pull`, `bundle install`, `bin/rails db:migrate`, `bin/rails db:seed`), whether a full `bin/rails db:reset` is needed, new gems/system packages, new env vars or credentials, and the command to start the app plus the URL to confirm it boots. List specifics — never "some dependencies changed." Say "None" where a category is unchanged.
 
-**Guided Walkthrough (`{{WALKTHROUGH}}`)** — one `<div class="story">` per scenario, in order. Each: a descriptive `.story-head` with a `.role-pill` for the user type; a click-to-copy login when it is a reserved-example identity, otherwise a placeholder (see Credentials), plus a copyable starting URL; extremely literal numbered steps; and a `.expect` expected result precise enough that a deviation is obvious. Include at least one scenario per affected role. Read the project's `CLAUDE.md` for audience/viewport guidance (mobile-first user types, dual-audience designs) and add matching scenarios.
+**Guided Walkthrough (`{{WALKTHROUGH}}`)** — one `<div class="story">` per scenario, in order. Each: a descriptive `.story-head` with a `.role-pill` for the user type; a click-to-copy login when it is a reserved-example identity, otherwise a placeholder (see Credentials), plus a copyable starting URL; extremely literal numbered steps; and a `.expect` expected result precise enough that a deviation is obvious. Include at least one scenario per affected role. Read `CLAUDE.md` for audience/viewport guidance and add matching scenarios.
 
-**Exploratory Testing (`{{EXPLORATORY}}`)** — an interactive `<ul class="checklist">`; each item `<li><label><input type="checkbox" data-check="..."> ...</label></li>`. Draw from debrief-flagged thin coverage, permission boundaries (accessing another user's data, role escalation), responsive/mobile checks for UI changes, and edge cases a developer might skip. The checkboxes are a self-tracking aid the tester ticks as they go — make each item self-describing.
+**Exploratory Testing (`{{EXPLORATORY}}`)** — an interactive `<ul class="checklist">`; each item `<li><label><input type="checkbox" data-check="..."> ...</label></li>`. Draw from debrief-flagged thin coverage, permission boundaries (accessing another user's data, role escalation), responsive/mobile checks, and edge cases a developer might skip. Make each item self-describing.
 
 **Test Suite (`{{TESTS}}`)** — commands to run the full suite and the targeted files most relevant to the new work, each a copy control. Note any known skips or expected failures.
 
-**Feedback** — already built into the template: a CTA button linking to the QA issue form via `{{REPORT_URL}}`. Do not reconstruct the form. If you fell back to the "no GitHub remote" case in step 4, replace the button paragraph with the tracker note instead.
+**Feedback** — built into the template: a CTA button linking to the QA issue form via `{{REPORT_URL}}`. Do not reconstruct the form.
+
+### Section content — Static-site path
+
+Fill each token with the content below. The checklist sections use an interactive `<ul class="checklist">` (each item `<li><label><input type="checkbox" data-check="..."> ...</label></li>`).
+
+**What's New (`{{WHATS_NEW}}`)** — a plain-language summary of what changed on the site (new or updated pages, redesigns, migrated content). 2–4 short paragraphs connecting to the goal. No jargon.
+
+**Where to Test (`{{WHERE}}`)** — the **deploy-preview URL** as a copy control (a Netlify deploy preview is typical). Add the local option for testers who clone: `git pull`, then `hugo server`, and the localhost URL — each a copy control. If the preview is access-gated, add a one-line preview-access note (placeholder only — see Credentials).
+
+**Guided Walkthrough (`{{WALKTHROUGH}}`)** — one `<div class="story">` per key page or flow, in reading order. The `.role-pill` is the visitor type (Visitor / Donor / Mobile visitor). Give a copyable starting URL (preview URL + path), literal numbered steps, and a `.expect` result. Cover the new/changed pages; add a mobile scenario per any `CLAUDE.md` viewport guidance.
+
+**Content & Links (`{{CONTENT}}`)** — checklist: copy accuracy (no lorem/placeholder; names, dates, figures, and contact info correct); every nav/footer/CTA link resolves; **old→new redirects resolve with no 404s** — when a redirect map/file exists, list the specific old URLs to verify; navigation works (menu, breadcrumbs, footer).
+
+**Donation Paths (`{{DONATION}}`) — optional** — include for giving/commerce/signup sites; delete the section and its TOC entry otherwise. Highest-stakes for a donor-facing site: exercise each give route end to end (mail-a-check address correct; PayPal link works and lands on the right account; any new platform flow completes), plus related form submissions (contact, newsletter) and their confirmations.
+
+**Responsive & Visual (`{{RESPONSIVE}}`)** — checklist: mobile/tablet/desktop layouts; images load and aren't distorted; logos, brand colors, and favicon render; no horizontal overflow; text readable; nav collapses correctly on small screens.
+
+**Meta & Sharing (`{{META}}`)** — checklist: page titles and meta descriptions present and accurate; social share cards (`og:image`, `og:title`, `twitter:*`) render when a page is shared; canonical URLs correct.
+
+**Accessibility (`{{A11Y}}`)** — checklist: images have meaningful alt text; color contrast is sufficient; keyboard navigation reaches all interactive elements with a visible focus state; heading order is logical. Spot checks, not an exhaustive audit.
+
+**Build & Health (`{{BUILD}}`)** — commands as copy controls: a clean production build (`hugo --gc --minify`) with no errors or warnings. Note checks to do on the preview: no browser console errors; no mixed-content (all assets over https). Actual broken-link crawling is out of scope for this skill — the Content & Links checklist covers links by hand.
+
+**Feedback** — built into the template: a CTA button linking to the QA issue form via `{{REPORT_URL}}`. Do not reconstruct the form.
 
 ---
 
@@ -71,20 +104,14 @@ Create `docs/qa-handoffs/` if it doesn't exist; use the same date-and-slug conve
 open docs/qa-handoffs/YYYY-MM-DD-[brief-topic].html
 ```
 
-Then tell the user where the file is and that the tester should: follow **Getting Current**, work through the walkthrough and tick the exploratory checklist, then click **File a QA report** for any findings — that opens the project's QA issue form (with drag-and-drop screenshots and auto-tagging) so the report lands in the tracker.
+Then tell the user where the file is and how the tester should use it: Rails — follow **Getting Current**, work the walkthrough, tick the exploratory checklist; static — open the **deploy-preview URL** from **Where to Test**, work the walkthrough, tick the checklists. In both cases, click **File a QA report** for any findings so it lands in the tracker.
 
 ## Publishing for remote testers (`--publish`)
 
-A remote tester who is not cloning the repo needs a hosted copy. With `--publish`, the skill uploads the saved HTML to the project's configured QA host so the tester can open it from a URL.
+A remote tester who is not cloning the repo needs a hosted copy. With `--publish`, the skill uploads the saved HTML to the project's configured QA host so the tester can open it from a URL. (This is unchanged across modes — the publish pipeline is framework-agnostic.)
 
 1. **Generate and save the HTML locally first** (the steps above). `--publish` operates on the saved file; it does not regenerate it.
-2. **Build a one-line blurb file** at `tmp/qa-handoff-comment.md` describing what is inside the HTML so a PR reader has context. One short paragraph — the HTML is the artifact, not a Markdown twin. Example:
-
-    ```markdown
-    Click-to-copy logins, interactive exploratory checklist, and a one-click
-    deep link to the project's QA report form are inside.
-    ```
-
+2. **Build a one-line blurb file** at `tmp/qa-handoff-comment.md` describing what is inside the HTML so a PR reader has context. One short paragraph — the HTML is the artifact, not a Markdown twin.
 3. **Confirm before publishing.** This is outward-facing: it pushes a file to a shared repo and, when `--pr <N>` is given, posts a PR comment. Get explicit approval first.
 4. **Call the shared publish pipeline:**
 
@@ -99,7 +126,7 @@ A remote tester who is not cloning the repo needs a hosted copy. With `--publish
     Behaviour:
     - **Target declared, no `--pr`** → uploads the HTML, prints the live Pages URL. Share that URL with the tester.
     - **Target declared, `--pr <N>` given** → also posts a PR comment with the live link above the blurb.
-    - **Target undeclared** → prints a warning and stays local. No PR comment (`--md-fallback-only` is not used here because the HTML is the artifact — a Markdown twin would lose the click-to-copy logins and the interactive checklist that make the handoff useful).
+    - **Target undeclared** → prints a warning and stays local. No PR comment (`--md-fallback-only` is not used here because the HTML is the artifact — a Markdown twin would lose the click-to-copy controls and the interactive checklists that make the handoff useful).
 
 5. Report back to the user with the Pages URL (and PR-comment confirmation when applicable).
 

--- a/claude/.claude/skills/qa-handoff/template-static.html
+++ b/claude/.claude/skills/qa-handoff/template-static.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <!--
   QA handoff structural template — STATIC SITE variant (Hugo and other static
-  site generators). The /qa-handoff skill uses this skeleton when the project is
+  site generators). The /qa-handoff skill fills this skeleton when the project is
   a static site; the Rails variant lives in template.html.
 
   How to use:
   - Copy this whole document, then replace the {{TOKENS}} and the annotated
     section regions with real content.
   - Produce a CLEAN artifact: strip every instructional comment (this head block
-    and the explanatory notes in the body). They guide template-filling only and
-    must not appear in the output. (HTML comments do not nest, so a stray
-    instructional comment can also break rendering.)
+    and the body notes). They guide template-filling only and must not appear in
+    the output. (HTML comments do not nest, so a stray instructional comment can
+    also break rendering.)
   - Inline the shared house style: copy the style block from
     ../_shared/house-style.html into the head (replacing the HOUSE STYLE marker)
     and its script block where the second HOUSE STYLE marker sits (before the
@@ -18,13 +18,12 @@
   - Make every command and URL the tester will paste a click-to-copy control: a
     button with class "copy" and a data-copy value.
   - The Feedback section is a CALL TO ACTION to the project's existing QA issue
-    form, not a reimplementation. Fill {{REPORT_URL}} with the deep link (see the
-    skill instructions). If no QA template exists, fall back to the plain
-    "issues/new" URL or a tracker note.
-  - The Donation Paths section is OPTIONAL: keep it for sites with giving /
-    commerce / signup flows (e.g. a nonprofit site), and fold related form checks
-    (contact, newsletter) into it. DELETE the section AND its TOC entry for a
-    purely informational site (e.g. a blog).
+    form, not a reimplementation. Fill {{REPORT_URL}} with the deep link.
+  - TWO sections are OPTIONAL. Delete the section AND its TOC entry when it
+    doesn't apply:
+      * Languages & Translations — delete for a single-language site.
+      * Key Flows & Forms — delete for a purely informational site (no forms,
+        donations, signups, or external-app handoffs).
 -->
 <html lang="en">
 <head>
@@ -43,7 +42,8 @@
       <li><a href="#where">Where to Test</a></li>
       <li><a href="#walkthrough">Guided Walkthrough</a></li>
       <li><a href="#content">Content &amp; Links</a></li>
-      <li><a href="#donation">Donation Paths</a></li>
+      <li><a href="#i18n">Languages &amp; Translations</a></li>
+      <li><a href="#flows">Key Flows &amp; Forms</a></li>
       <li><a href="#responsive">Responsive &amp; Visual</a></li>
       <li><a href="#meta">Meta &amp; Sharing</a></li>
       <li><a href="#a11y">Accessibility</a></li>
@@ -78,7 +78,10 @@
       <div class="section-body">
         <!-- The deploy-preview URL the tester opens (e.g. a Netlify deploy preview) as a click-to-copy control.
              Optional: local preview for testers who clone (git pull, then `hugo server`, and the localhost URL).
-             Optional: a "preview access" note if the deploy preview is password-gated — placeholder only, never a real secret. -->
+             Optional: a "preview access" note if the deploy preview is password-gated — placeholder only, never a real secret.
+             ENVIRONMENT LIMITS: call out checks that CANNOT be done on a per-PR deploy preview — e.g. an external API with a
+             CORS allowlist, or form-email notifications that only fire in production — and say which environment to use for each
+             (per-PR preview vs. branch deploy vs. production), so testers don't file false "broken form" reports. -->
         {{WHERE}}
       </div>
     </details>
@@ -96,28 +99,47 @@
       <summary>Content &amp; Links</summary>
       <div class="section-body">
         <!-- Interactive checklist <ul class="checklist">: copy accuracy (no lorem/placeholder; names/dates/figures/contact correct);
-             every nav/footer/CTA link resolves; OLD -> NEW redirects resolve with no 404s (list specific old URLs to verify when a
-             redirect map exists in the repo); navigation (menu, breadcrumbs, footer). -->
+             every nav/footer/CTA link resolves; navigation (menu, breadcrumbs, footer).
+             URL CONTINUITY (migrations): Hugo migrations often preserve old URLs by slug-matching, not redirect maps. Check BOTH
+             directions — (a) every preserved old URL still resolves at the same path, and (b) every REMOVED old URL is intentionally
+             gone (redirect it if it was indexed/linked, or accept the 404). -->
         {{CONTENT}}
       </div>
     </details>
 
-    <details class="section" id="donation" open>
-      <!-- OPTIONAL section — see head note. Keep for giving/commerce/signup sites; fold contact/newsletter form checks in here. Delete this whole block + its TOC entry for an informational-only site. -->
-      <summary>Donation Paths</summary>
+    <details class="section" id="i18n" open>
+      <!-- OPTIONAL section — see head note. Keep for multilingual sites; DELETE this block + its TOC entry for a single-language site. -->
+      <summary>Languages &amp; Translations</summary>
       <div class="section-body">
-        <!-- Highest-stakes for a donor-facing site. Exercise each give route end to end as a checklist:
-             mail-a-check address correct; PayPal link works and lands on the right account; any new platform (e.g. iDonate) flow completes.
-             Include related form submissions (contact, newsletter) and their confirmations. -->
-        {{DONATION}}
+        <!-- Checklist: the language switcher works and appears only where a translation exists (not on single-language pages);
+             each language's URLs resolve and routes with no translation 404 intentionally (not a broken page); hreflang tags link
+             the language variants; translated pages show the target language throughout (no silent fallback to the default
+             language); language-specific metadata (og:locale) is correct. -->
+        {{I18N}}
+      </div>
+    </details>
+
+    <details class="section" id="flows" open>
+      <!-- OPTIONAL section — see head note. Keep for sites with conversion/action paths; DELETE this block + its TOC entry for a purely informational site. -->
+      <summary>Key Flows &amp; Forms</summary>
+      <div class="section-body">
+        <!-- Exercise the site's primary actions end to end as a checklist:
+             - Donations (when present — first-class for donor-giving sites): each give route works (mail-a-check address correct;
+               PayPal link lands on the right account; any new platform flow completes).
+             - Forms by backend: list each form, its backend, WHERE it can actually be tested (see Where to Test), and its success
+               UX (often an inline message, not a redirect).
+             - External-app handoffs: links/CTAs that hand off to a separate app or domain land correctly.
+             - Disabled/empty states: if a form/flow can be toggled off (out-of-stock, closed), the off state replaces it cleanly. -->
+        {{FLOWS}}
       </div>
     </details>
 
     <details class="section" id="responsive" open>
       <summary>Responsive &amp; Visual</summary>
       <div class="section-body">
-        <!-- Checklist: mobile / tablet / desktop layouts; images load and aren't distorted; logos, brand colors, and favicon render;
-             no horizontal overflow; text readable; nav collapses correctly on small screens. -->
+        <!-- Checklist: mobile / tablet / desktop layouts; images load and aren't distorted; logos, brand colors, favicon and any
+             PWA manifest render; no horizontal overflow; text readable; nav collapses on small screens; no flash-of-unstyled-content
+             (FOUC) on load, especially for sticky or scroll-reactive headers. -->
         {{RESPONSIVE}}
       </div>
     </details>
@@ -125,8 +147,8 @@
     <details class="section" id="meta" open>
       <summary>Meta &amp; Sharing</summary>
       <div class="section-body">
-        <!-- Checklist: page titles and meta descriptions present and accurate; social share cards (og:image, og:title, twitter:*) render
-             when a page is shared; canonical URLs correct; favicon present. -->
+        <!-- Checklist: page titles and meta descriptions present and accurate; social share cards (og:image, og:title, twitter:*)
+             render when a page is shared; canonical URLs correct; favicon present. (hreflang is checked in Languages & Translations.) -->
         {{META}}
       </div>
     </details>
@@ -134,8 +156,8 @@
     <details class="section" id="a11y" open>
       <summary>Accessibility</summary>
       <div class="section-body">
-        <!-- Checklist: images have meaningful alt text; color contrast is sufficient; keyboard navigation reaches all interactive elements
-             with a visible focus state; heading order is logical. Spot checks, not an exhaustive audit. -->
+        <!-- Checklist: images have meaningful alt text in the site's language(s); color contrast is sufficient; keyboard navigation
+             reaches all interactive elements with a visible focus state; heading order is logical. Spot checks, not a full audit. -->
         {{A11Y}}
       </div>
     </details>
@@ -144,7 +166,9 @@
       <summary>Build &amp; Health</summary>
       <div class="section-body">
         <!-- Commands as click-to-copy controls: a clean production build (e.g. `hugo --gc --minify`) with no errors or warnings.
-             Note checks to do on the preview: no browser console errors; no mixed-content (all assets over https). -->
+             A green build is NOT enough — also verify: interactive JS still works AFTER minification (tree-shaking can silently drop
+             handlers a dev build kept); the pinned Hugo version matches across deploy config and CI (netlify.toml, .github/workflows/);
+             on the preview, no browser console errors and no mixed-content (all assets over https). -->
         {{BUILD}}
       </div>
     </details>

--- a/claude/.claude/skills/qa-handoff/template-static.html
+++ b/claude/.claude/skills/qa-handoff/template-static.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<!--
+  QA handoff structural template — STATIC SITE variant (Hugo and other static
+  site generators). The /qa-handoff skill uses this skeleton when the project is
+  a static site; the Rails variant lives in template.html.
+
+  How to use:
+  - Copy this whole document, then replace the {{TOKENS}} and the annotated
+    section regions with real content.
+  - Produce a CLEAN artifact: strip every instructional comment (this head block
+    and the explanatory notes in the body). They guide template-filling only and
+    must not appear in the output. (HTML comments do not nest, so a stray
+    instructional comment can also break rendering.)
+  - Inline the shared house style: copy the style block from
+    ../_shared/house-style.html into the head (replacing the HOUSE STYLE marker)
+    and its script block where the second HOUSE STYLE marker sits (before the
+    closing body tag). Do NOT link external assets.
+  - Make every command and URL the tester will paste a click-to-copy control: a
+    button with class "copy" and a data-copy value.
+  - The Feedback section is a CALL TO ACTION to the project's existing QA issue
+    form, not a reimplementation. Fill {{REPORT_URL}} with the deep link (see the
+    skill instructions). If no QA template exists, fall back to the plain
+    "issues/new" URL or a tracker note.
+  - The Donation Paths section is OPTIONAL: keep it for sites with giving /
+    commerce / signup flows (e.g. a nonprofit site), and fold related form checks
+    (contact, newsletter) into it. DELETE the section AND its TOC entry for a
+    purely informational site (e.g. a blog).
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{PROJECT}} — QA Handoff: {{TITLE}}</title>
+<!-- HOUSE STYLE: inline the <style> block from ../_shared/house-style.html here -->
+</head>
+<body>
+<div class="wrap">
+
+  <nav class="toc">
+    <h2>Contents</h2>
+    <ol>
+      <li><a href="#new">What's New</a></li>
+      <li><a href="#where">Where to Test</a></li>
+      <li><a href="#walkthrough">Guided Walkthrough</a></li>
+      <li><a href="#content">Content &amp; Links</a></li>
+      <li><a href="#donation">Donation Paths</a></li>
+      <li><a href="#responsive">Responsive &amp; Visual</a></li>
+      <li><a href="#meta">Meta &amp; Sharing</a></li>
+      <li><a href="#a11y">Accessibility</a></li>
+      <li><a href="#build">Build &amp; Health</a></li>
+      <li><a href="#feedback">Feedback</a></li>
+    </ol>
+  </nav>
+
+  <main>
+    <header class="doc">
+      <p class="eyebrow">{{PROJECT}} · QA Handoff</p>
+      <h1>{{TITLE}}</h1>
+      <dl class="meta">
+        <dt>Project</dt><dd>{{PROJECT}}</dd>
+        <dt>Date</dt><dd>{{DATE}}</dd>
+        <dt>Branch</dt><dd>{{BRANCH}}</dd>
+        <dt>Commit</dt><dd>{{COMMIT}}</dd>
+        <dt>Preview</dt><dd>{{PREVIEW_URL}}</dd>
+      </dl>
+    </header>
+
+    <details class="section" id="new" open>
+      <summary>What's New</summary>
+      <div class="section-body">
+        <!-- Plain-language summary of what changed on the site; connect to the roadmap/goal. No file paths / jargon. -->
+        {{WHATS_NEW}}
+      </div>
+    </details>
+
+    <details class="section" id="where" open>
+      <summary>Where to Test</summary>
+      <div class="section-body">
+        <!-- The deploy-preview URL the tester opens (e.g. a Netlify deploy preview) as a click-to-copy control.
+             Optional: local preview for testers who clone (git pull, then `hugo server`, and the localhost URL).
+             Optional: a "preview access" note if the deploy preview is password-gated — placeholder only, never a real secret. -->
+        {{WHERE}}
+      </div>
+    </details>
+
+    <details class="section" id="walkthrough" open>
+      <summary>Guided Walkthrough</summary>
+      <div class="section-body">
+        <!-- One <div class="story"> per key page/flow; role pill is the visitor type (Visitor / Donor / Mobile visitor);
+             a copyable starting URL (preview URL + path); literal numbered steps; a .expect expected result. -->
+        {{WALKTHROUGH}}
+      </div>
+    </details>
+
+    <details class="section" id="content" open>
+      <summary>Content &amp; Links</summary>
+      <div class="section-body">
+        <!-- Interactive checklist <ul class="checklist">: copy accuracy (no lorem/placeholder; names/dates/figures/contact correct);
+             every nav/footer/CTA link resolves; OLD -> NEW redirects resolve with no 404s (list specific old URLs to verify when a
+             redirect map exists in the repo); navigation (menu, breadcrumbs, footer). -->
+        {{CONTENT}}
+      </div>
+    </details>
+
+    <details class="section" id="donation" open>
+      <!-- OPTIONAL section — see head note. Keep for giving/commerce/signup sites; fold contact/newsletter form checks in here. Delete this whole block + its TOC entry for an informational-only site. -->
+      <summary>Donation Paths</summary>
+      <div class="section-body">
+        <!-- Highest-stakes for a donor-facing site. Exercise each give route end to end as a checklist:
+             mail-a-check address correct; PayPal link works and lands on the right account; any new platform (e.g. iDonate) flow completes.
+             Include related form submissions (contact, newsletter) and their confirmations. -->
+        {{DONATION}}
+      </div>
+    </details>
+
+    <details class="section" id="responsive" open>
+      <summary>Responsive &amp; Visual</summary>
+      <div class="section-body">
+        <!-- Checklist: mobile / tablet / desktop layouts; images load and aren't distorted; logos, brand colors, and favicon render;
+             no horizontal overflow; text readable; nav collapses correctly on small screens. -->
+        {{RESPONSIVE}}
+      </div>
+    </details>
+
+    <details class="section" id="meta" open>
+      <summary>Meta &amp; Sharing</summary>
+      <div class="section-body">
+        <!-- Checklist: page titles and meta descriptions present and accurate; social share cards (og:image, og:title, twitter:*) render
+             when a page is shared; canonical URLs correct; favicon present. -->
+        {{META}}
+      </div>
+    </details>
+
+    <details class="section" id="a11y" open>
+      <summary>Accessibility</summary>
+      <div class="section-body">
+        <!-- Checklist: images have meaningful alt text; color contrast is sufficient; keyboard navigation reaches all interactive elements
+             with a visible focus state; heading order is logical. Spot checks, not an exhaustive audit. -->
+        {{A11Y}}
+      </div>
+    </details>
+
+    <details class="section" id="build">
+      <summary>Build &amp; Health</summary>
+      <div class="section-body">
+        <!-- Commands as click-to-copy controls: a clean production build (e.g. `hugo --gc --minify`) with no errors or warnings.
+             Note checks to do on the preview: no browser console errors; no mixed-content (all assets over https). -->
+        {{BUILD}}
+      </div>
+    </details>
+
+    <details class="section" id="feedback" open>
+      <summary>Found something? File a QA report</summary>
+      <div class="section-body">
+        <p>Report findings using the project's QA issue form — it has dedicated fields for steps, expected vs. actual behavior, screenshots (drag-and-drop), browser/device, and more, and the issue is auto-tagged for triage.</p>
+        <p><a class="btn" href="{{REPORT_URL}}" target="_blank" rel="noopener">File a QA report &rarr;</a></p>
+      </div>
+    </details>
+
+    <footer class="doc">
+      Generated by the <code>/qa-handoff</code> skill · {{DATE}}
+    </footer>
+  </main>
+</div>
+<!-- HOUSE STYLE: inline the <script> block from ../_shared/house-style.html here -->
+</body>
+</html>


### PR DESCRIPTION
## Summary

Relaxes `/qa-handoff`'s hard Rails-only gate so it also serves **static (Hugo) sites** — unblocking QA handoffs for the upcoming OFReport and ETO Web Reboot sites. The artifact format and publish pipeline were always framework-agnostic; only the gate and the section content were Rails-coupled.

## Design

Two modes behind one detection step, sharing all the plumbing:

```
detect: Gemfile + bin/rails          → Rails path (unchanged)
        hugo config + content/       → static path (new)
        neither                      → "not applicable"
```

A **second template** (`template-static.html`) carries the static sections, rather than over-parameterizing the Rails template — the section sets genuinely differ.

## Static-site checklist (the spine)

What's New · Where to Test (deploy-preview URL — Netlify is the working assumption, but host-agnostic; flags checks that can't run on a per-PR preview) · Guided Walkthrough (page tours) · **Content & Links** (copy accuracy + links resolve + URL continuity: preserved URLs still resolve, removed URLs intentionally gone) · **Languages & Translations** _(optional — multilingual sites: switcher visibility, per-language URLs, hreflang, no fallback leakage, intentional 404s)_ · **Key Flows & Forms** _(optional — donations first-class when present; forms-by-backend matrix; external-app handoffs)_ · Responsive & Visual (+ FOUC) · Meta & Sharing · Accessibility · Build & Health (`hugo --gc --minify` + JS-survives-minification + Hugo version-pin consistency) · Feedback.

## Grounded in a real migration

The static checklist was validated against the **completed dobroizlo.com.ua Nuxt→Hugo migration** (a Ukrainian nonprofit site). That surfaced six refinements (second commit) — most importantly the **multilingual** section and the **per-PR-preview environment limits**: that project's book-request form is CORS-blocked on deploy previews, which would have produced false "broken form" bug reports from testers. The redirect check was also reframed to match the real Hugo pattern (slug-matching, not redirect maps), and Build & Health hardened with two gotchas a green build hides (minification tree-shaking, Hugo version drift).

## Changes

- `skills/qa-handoff/SKILL.md` — Step 0 detection replaces the hard gate; a parallel static-site section guide; credentials policy extended to optional (password-gated) preview access. Rails path untouched.
- `skills/qa-handoff/template-static.html` — new static template (11 sections; **Languages & Translations** and **Key Flows & Forms** marked optional, deleted when N/A).

## Scope notes / honest caveats

- **Validated against a real Hugo project, but not yet rendered end-to-end.** The design is pressure-tested against a site that actually shipped (including the preview-CORS trap), but the first live render on OFReport/ETO is the final validation.
- **No automated link-crawler.** Redirect/link checking is instructed (and listed from a redirect map when present), but crawling is intentionally a candidate tool for the ETO work, not pre-built here.
- Does **not** touch the house-style marker inconsistency (separate audit item M2).

Closes #196
