### PR TITLE
fix(claude): resolve publish-artifact Pages URL from the Pages API (CNAME support)

### DIFF
--- a/claude/.claude/docs/prd-workflow/spec-driven-development.md
+++ b/claude/.claude/docs/prd-workflow/spec-driven-development.md
@@ -417,7 +417,7 @@ Note how `/drift-check` intensity tracks project maturity: critical during green
 
 `/walkthrough` and `/qa-handoff` produce HTML artifacts. A remote tester who is not cloning the repo needs a hosted copy. Publishing is per-project opt-in, declared in the project's own `CLAUDE.md`: a `## QA Publish Target` heading followed by a `yaml` fenced code block containing `repo: <owner>/<pages-repo>` and `subfolder: <project-slug>`. See the bootstrap template at `~/.claude/docs/prd-workflow/templates/CLAUDE.md` for the exact block.
 
-The repo must have GitHub Pages enabled and served from the **default branch** (the Contents API writes there); the live URL is derived as `https://<owner>.github.io/<pages-repo>/<subfolder>/<file>.html`. A user/org-pages repo (named `<owner>.github.io`) is served at the apex with no repo segment — the pipeline detects that and emits the correct URL with a warning so the configuration is visible.
+The repo must have GitHub Pages enabled and served from the **default branch** (the Contents API writes there). The live URL is read straight from the Pages API (`GET /repos/{owner}/{repo}/pages` → `html_url`), which already returns the correct base for project pages, user/org pages, AND custom-domain (CNAME) sites — so there is no repo-name guessing. If Pages is not enabled, the pipeline fails fast with a clear message before uploading rather than emitting a link that would not resolve.
 
 The shared pipeline at `~/.claude/skills/_shared/publish-artifact.sh` reads that block, uploads the HTML via the GitHub Contents API (create or update via SHA), and — when given `--pr <N>` — posts a PR comment with the live link.
 

--- a/claude/.claude/skills/_shared/publish-artifact.sh
+++ b/claude/.claude/skills/_shared/publish-artifact.sh
@@ -102,8 +102,19 @@ if (( valid_target == 0 )); then
 fi
 
 dest_path="${subfolder}/$(basename "${html}")"
-owner="${repo%%/*}"
-repo_name="${repo#*/}"
+
+# Resolve the live URL from the GitHub Pages API instead of guessing it from
+# the repo name. `html_url` is a single source of truth: it already returns
+# the correct base for project pages, user/org pages, AND custom-domain
+# (CNAME) sites. If Pages isn't enabled we could only print a URL that won't
+# resolve, so fail fast — before uploading — rather than publishing an orphan
+# file with a dead link.
+if ! pages_info=$(gh api "repos/${repo}/pages" 2>/dev/null); then
+  die "GitHub Pages is not enabled for ${repo} — enable Pages (or fix the QA Publish Target) before publishing"
+fi
+pages_base=$(printf '%s' "${pages_info}" | jq -r '.html_url // empty' | sed 's:/*$::')
+[[ -n "${pages_base}" ]] || die "GitHub Pages API returned no html_url for ${repo} — cannot derive a live URL"
+pages_url="${pages_base}/${dest_path}"
 
 source_repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo "unknown")
 short_sha=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -140,15 +151,6 @@ fi
 
 gh api -X PUT "repos/${repo}/contents/${dest_path}" --input "${payload_file}" >/dev/null
 
-# Pages URL assumes a project-pages repo served from the default branch. A
-# user/org-pages repo (named "<owner>.github.io") is served at the apex with
-# no <repo> path segment, so the project-pages template would be wrong.
-if [[ "${repo_name}" == "${owner}.github.io" ]]; then
-  warn "repo '${repo}' looks like a user/org-pages repo — the live URL omits the repo segment; verify GitHub Pages settings"
-  pages_url="https://${repo_name}/${dest_path}"
-else
-  pages_url="https://${owner}.github.io/${repo_name}/${dest_path}"
-fi
 echo "${pages_url}"
 
 if [[ -n "${pr}" ]]; then

--- a/tests/publish_artifact/test_publish_artifact.bats
+++ b/tests/publish_artifact/test_publish_artifact.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+
+# Tests for claude/.claude/skills/_shared/publish-artifact.sh
+#
+# Focus: the live Pages URL is resolved from the GitHub Pages API `html_url`
+# (issue #180), so it is correct for project pages, user/org pages, AND
+# custom-domain (CNAME) sites — and the script fails before uploading when
+# Pages is not enabled.
+#
+# `gh` is stubbed by a dispatcher on PATH (see setup). The stub logs every
+# call to GH_CALL_LOG and captures any PR comment body to GH_PR_COMMENT_BODY,
+# so tests can assert both the printed URL and what reached the PR comment.
+# The Pages API is "enabled" only when GH_PAGES_FIXTURE exists on disk — each
+# test copies the fixture it wants there (or leaves it absent for the
+# Pages-disabled case), which keeps all state on the filesystem and out of the
+# per-test subshell environment.
+
+load '../helpers/common.bash'
+load '../helpers/shell_helpers.bash'
+
+setup() {
+  save_original_path
+  load_dotfiles_variable
+
+  SCRIPT="${DOTFILES}/claude/.claude/skills/_shared/publish-artifact.sh"
+
+  TEST_TMPDIR=$(mktemp -d)
+  export GH_CALL_LOG="${TEST_TMPDIR}/gh-calls.log"
+  export GH_PR_COMMENT_BODY="${TEST_TMPDIR}/pr-comment-body.md"
+  export GH_PAGES_FIXTURE="${TEST_TMPDIR}/active-pages.json"
+  : > "${GH_CALL_LOG}"
+
+  # Pages API fixtures — shapes match the real GET /repos/{repo}/pages payload.
+  cat > "${TEST_TMPDIR}/pages-cname.json" <<'JSON'
+{"cname":"joshukraine.com","html_url":"https://joshukraine.com/","source":{"branch":"main","path":"/"}}
+JSON
+  cat > "${TEST_TMPDIR}/pages-project.json" <<'JSON'
+{"cname":null,"html_url":"https://euroteamoutreach.github.io/qa-walkthroughs/","source":{"branch":"main","path":"/"}}
+JSON
+
+  # A minimal HTML artifact to publish.
+  HTML="${TEST_TMPDIR}/report.html"
+  echo '<!doctype html><title>QA</title>' > "${HTML}"
+
+  # gh stub: dispatches on args, records calls, never touches the network.
+  STUB_BIN="${TEST_TMPDIR}/bin"
+  mkdir -p "${STUB_BIN}"
+  cat > "${STUB_BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${GH_CALL_LOG}"
+
+# Upload (create/update file): gh api -X PUT repos/<repo>/contents/<path>
+case " $* " in
+  *" -X PUT "*) echo '{}'; exit 0 ;;
+esac
+
+case "$1" in
+  api)
+    case "$2" in
+      */pages)
+        # Pages is "enabled" only when the active fixture exists; otherwise
+        # emulate the real 404 from a repo without Pages.
+        if [[ -f "${GH_PAGES_FIXTURE}" ]]; then
+          cat "${GH_PAGES_FIXTURE}"; exit 0
+        fi
+        echo "gh: Not Found (HTTP 404)" >&2; exit 1
+        ;;
+      */contents/*)
+        # GET existing file — emulate "not present yet" (new upload).
+        exit 1
+        ;;
+    esac
+    ;;
+  repo)  echo "test-owner/source-repo"; exit 0 ;;
+  pr)
+    # Capture the comment body so tests can inspect the live link.
+    while [[ $# -gt 0 ]]; do
+      if [[ "$1" == "--body-file" ]]; then cp "$2" "${GH_PR_COMMENT_BODY}"; break; fi
+      shift
+    done
+    exit 0
+    ;;
+esac
+exit 0
+STUB
+  chmod +x "${STUB_BIN}/gh"
+  export PATH="${STUB_BIN}:${PATH}"
+}
+
+teardown() {
+  restore_path
+  rm -rf "${TEST_TMPDIR}"
+}
+
+# Mark the Pages API as enabled for the active repo, serving the given fixture.
+enable_pages() {
+  cp "$1" "${GH_PAGES_FIXTURE}"
+}
+
+# Write a project CLAUDE.md with a QA Publish Target block for the given
+# repo/subfolder, into a fresh project root, and echo that root.
+make_project_root() {
+  local repo="$1" subfolder="$2"
+  local root
+  root=$(mktemp -d "${TEST_TMPDIR}/project.XXXXXX")
+  cat > "${root}/CLAUDE.md" <<MD
+# Project
+
+## QA Publish Target
+
+\`\`\`yaml
+repo: ${repo}
+subfolder: ${subfolder}
+\`\`\`
+MD
+  echo "${root}"
+}
+
+@test "custom-domain (CNAME) repo emits the CNAME-based URL on stdout" {
+  enable_pages "${TEST_TMPDIR}/pages-cname.json"
+  local root
+  root=$(make_project_root "joshukraine/joshukraine.github.io" "qa")
+
+  run "${SCRIPT}" --html "${HTML}" --label "QA Report" --project-root "${root}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "https://joshukraine.com/qa/report.html" ]
+  # The github.io host must never appear for a custom-domain site.
+  [[ "${output}" != *"github.io"* ]]
+}
+
+@test "project-pages repo emits the project-pages URL (unchanged behavior)" {
+  enable_pages "${TEST_TMPDIR}/pages-project.json"
+  local root
+  root=$(make_project_root "euroteamoutreach/qa-walkthroughs" "qa")
+
+  run "${SCRIPT}" --html "${HTML}" --label "QA Report" --project-root "${root}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "https://euroteamoutreach.github.io/qa-walkthroughs/qa/report.html" ]
+}
+
+@test "repo without Pages enabled dies with a clear message" {
+  # No enable_pages call — the stub emulates a 404 from the Pages API.
+  local root
+  root=$(make_project_root "joshukraine/dotfiles" "qa")
+
+  run "${SCRIPT}" --html "${HTML}" --label "QA Report" --project-root "${root}"
+
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"Pages is not enabled"* ]]
+}
+
+@test "no upload happens when Pages is not enabled (fail before PUT)" {
+  local root
+  root=$(make_project_root "joshukraine/dotfiles" "qa")
+
+  run "${SCRIPT}" --html "${HTML}" --label "QA Report" --project-root "${root}"
+
+  [ "${status}" -ne 0 ]
+  # The die must happen before any Contents-API upload.
+  run grep -F -- "-X PUT" "${GH_CALL_LOG}"
+  [ "${status}" -ne 0 ]
+}
+
+@test "PR comment links to the CNAME URL" {
+  enable_pages "${TEST_TMPDIR}/pages-cname.json"
+  local root
+  root=$(make_project_root "joshukraine/joshukraine.github.io" "qa")
+
+  run "${SCRIPT}" --html "${HTML}" --label "QA Report" --pr 42 --project-root "${root}"
+
+  [ "${status}" -eq 0 ]
+  [ -f "${GH_PR_COMMENT_BODY}" ]
+  run grep -F "https://joshukraine.com/qa/report.html" "${GH_PR_COMMENT_BODY}"
+  [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- `publish-artifact.sh` derived the live GitHub Pages URL by templating the repo name (`https://<owner>.github.io/<repo>/...`), which is wrong for any Pages site behind a custom domain (CNAME) — it would print a `github.io` link that doesn't resolve.
- Resolve the served base from the Pages API (`GET /repos/{owner}/{repo}/pages` → `html_url`) instead, the single value that's already correct for project pages, user/org pages, **and** custom-domain sites.
- Query Pages **before** the upload so a repo without Pages enabled fails fast with a clear message rather than pushing an orphan file and printing a dead link.

## Changes

- **fix:** replace the three-branch repo-name URL derivation (and its user/org-pages warning + now-dead `owner`/`repo_name` vars) with one `html_url` lookup; `die` early when Pages is disabled or returns no `html_url`.
- **test:** new `tests/publish_artifact/` bats suite that stubs `gh` via a PATH dispatcher (logs calls, captures the PR-comment body) covering all acceptance behaviors.
- **docs:** update spec-driven-development handbook §7 to describe Pages-API URL resolution and the fail-fast-on-disabled behavior, dropping the old project-vs-user-pages caveat.

## Testing

- [x] `./scripts/run-tests` — 77/77 pass (72 prior + 5 new)
- [x] `./scripts/lint-shell` clean; all pre-commit hooks pass
- [x] Validated against the live Pages API: custom-domain → `https://joshukraine.com/`, project → `https://euroteamoutreach.github.io/qa-walkthroughs/`, disabled → 404

New tests cover:
- custom-domain (CNAME) repo emits the custom-domain URL on stdout **and** in the PR comment
- project-pages repo URL unchanged
- repo without Pages dies with a clear message, **before** any upload

## Notes

- The issue sketched querying Pages *after* the upload; I moved it *before* so a Pages-disabled repo never leaves an orphan HTML file in the publish repo. Easily reversible.
- One extra `gh api` call per publish — negligible, and not on a hot path.

Closes #180
