### PR TITLE
feat(tmux): add per-project status bar accent color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ local/*
 startup.conf
 tmux/.config/tmux/plugins
 tmux/.config/tmux/tmux.conf.local
+tmux/.config/tmux/project-accent.local.sh
 vim/.netrwhist
 vim/bundle
 

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ Local customizations should be placed in `*.local` files:
 
 ### Per-project tmux accent
 
-When several projects are open at once — one tmux session each, created with [`tat`](bin/.local/bin/tat) — the session-name "pill" at the left of the status bar can be color-coded per project so they're easy to tell apart. Sessions without a mapping keep the theme's default blue, so this is a no-op until you opt in.
+When several projects are open at once — one tmux session each, created with [`tat`](bin/.local/bin/tat) — the status bar can be color-coded per project so they're easy to tell apart. Both ends of the bar are accented: the session-name "pill" on the left and the hostname pill on the right, giving a matching color band on each side that's easy to catch at a glance. Sessions without a mapping keep the theme's default blue, so this is a no-op until you opt in.
 
 To enable it, copy the example map and edit it:
 
@@ -539,7 +539,7 @@ Colors can be hex (`#rrggbb`), a named color (`red`), or `colour0`–`colour255`
 
 > **Note:** the lookup key is the **tmux session name**, not the directory path. With [`tat`](bin/.local/bin/tat) the session name is the current directory's basename with dots converted to dashes (a `foo.bar` directory becomes session `foo-bar`), so map it as `foo-bar`. Keying on the session name lets two checkouts that share a directory name (e.g. `bfo1` and `bfo2`) still get distinct colors.
 
-Colors apply automatically to new sessions (via a `session-created` hook) and backfill existing sessions whenever tmux is reloaded. The override mirrors the active theme; if you switch away from TokyoNight Moon, re-derive the `status-left` line — see the comments in `~/.config/tmux/project-accent.tmux`.
+Colors apply automatically to new sessions (via a `session-created` hook) and backfill existing sessions whenever tmux is reloaded. The color is driven entirely by the `@accent` user option, which the theme renders into both pills; if you switch away from TokyoNight Moon, parameterize the new theme's pills with `#{@accent}` — see the comments in `~/.config/tmux/themes/tokyonight_moon.tmux`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -509,6 +509,37 @@ Local customizations should be placed in `*.local` files:
 - `~/.laptop.local` - Additional laptop setup customizations
 - `~/.config/ghostty/config.local` - Personal ghostty overrides (keybinds, fonts, theme)
 - `~/.config/tmux/tmux.conf.local` - Personal tmux overrides (extra plugins, key bindings, options)
+- `~/.config/tmux/project-accent.local.sh` - Per-project status bar accent colors (see below)
+
+### Per-project tmux accent
+
+When several projects are open at once — one tmux session each, created with [`tat`](bin/.local/bin/tat) — the session-name "pill" at the left of the status bar can be color-coded per project so they're easy to tell apart. Sessions without a mapping keep the theme's default blue, so this is a no-op until you opt in.
+
+To enable it, copy the example map and edit it:
+
+```sh
+cd ~/.config/tmux
+cp project-accent.local.sh.example project-accent.local.sh
+$EDITOR project-accent.local.sh
+```
+
+Map each project to a color in the `accent_for` function:
+
+```sh
+accent_for() {
+  case "$1" in
+    my_work_app) printf '%s' "#ff966c" ;;  # orange
+    my_side_proj) printf '%s' "#c3e88d" ;; # green
+    *) printf '%s' "" ;;
+  esac
+}
+```
+
+Colors can be hex (`#rrggbb`), a named color (`red`), or `colour0`–`colour255`. The real `project-accent.local.sh` is gitignored, so your project names and color choices never leave your machine.
+
+> **Note:** the lookup key is the **project directory's basename**, not the tmux session name. `tat` converts dots to dashes in the session _name_ (so a `foo.bar` directory shows as session `foo-bar`), but the map keys on the raw directory name — use `foo.bar`.
+
+Colors apply automatically to new sessions (via a `session-created` hook) and backfill existing sessions whenever tmux is reloaded. The override mirrors the active theme; if you switch away from TokyoNight Moon, re-derive the `status-left` line — see the comments in `~/.config/tmux/project-accent.tmux`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -523,13 +523,13 @@ cp project-accent.local.sh.example project-accent.local.sh
 $EDITOR project-accent.local.sh
 ```
 
-Map each project to a color in the `accent_for` function:
+Map each session to a color in the `accent_for` function, keyed by the tmux session name (the `#S` shown in the pill):
 
 ```sh
 accent_for() {
   case "$1" in
-    my_work_app) printf '%s' "#ff966c" ;;  # orange
-    my_side_proj) printf '%s' "#c3e88d" ;; # green
+    my-work-app) printf '%s' "#ff966c" ;;  # orange
+    my-side-proj) printf '%s' "#c3e88d" ;; # green
     *) printf '%s' "" ;;
   esac
 }
@@ -537,7 +537,7 @@ accent_for() {
 
 Colors can be hex (`#rrggbb`), a named color (`red`), or `colour0`–`colour255`. The real `project-accent.local.sh` is gitignored, so your project names and color choices never leave your machine.
 
-> **Note:** the lookup key is the **project directory's basename**, not the tmux session name. `tat` converts dots to dashes in the session _name_ (so a `foo.bar` directory shows as session `foo-bar`), but the map keys on the raw directory name — use `foo.bar`.
+> **Note:** the lookup key is the **tmux session name**, not the directory path. With [`tat`](bin/.local/bin/tat) the session name is the current directory's basename with dots converted to dashes (a `foo.bar` directory becomes session `foo-bar`), so map it as `foo-bar`. Keying on the session name lets two checkouts that share a directory name (e.g. `bfo1` and `bfo2`) still get distinct colors.
 
 Colors apply automatically to new sessions (via a `session-created` hook) and backfill existing sessions whenever tmux is reloaded. The override mirrors the active theme; if you switch away from TokyoNight Moon, re-derive the `status-left` line — see the comments in `~/.config/tmux/project-accent.tmux`.
 

--- a/tmux/.config/tmux/project-accent.local.sh.example
+++ b/tmux/.config/tmux/project-accent.local.sh.example
@@ -6,12 +6,14 @@
 # real file is gitignored, so your project names and color choices never get
 # committed or published.
 #
-# Map each project directory's basename to a color: hex (#rrggbb), a named
-# color (e.g. "red"), or colour0-255. Return empty to keep the theme default.
+# Map each tmux session name (the `#S` shown in the status-bar pill) to a color:
+# hex (#rrggbb), a named color (e.g. "red"), or colour0-255. Return empty to keep
+# the theme default. With `tat`, the session name is the directory's basename with
+# dots converted to dashes -- so a `my.app` directory is session `my-app`.
 accent_for() {
   case "$1" in
-    my_work_app) printf '%s' "#ff966c" ;;  # orange
-    my_side_proj) printf '%s' "#c3e88d" ;; # green
+    my-work-app) printf '%s' "#ff966c" ;;  # orange
+    my-side-proj) printf '%s' "#c3e88d" ;; # green
     *) printf '%s' "" ;;
   esac
 }

--- a/tmux/.config/tmux/project-accent.local.sh.example
+++ b/tmux/.config/tmux/project-accent.local.sh.example
@@ -1,0 +1,17 @@
+# shellcheck shell=bash
+#
+# Per-project tmux status accent -- EXAMPLE template.
+#
+# Copy this file to `project-accent.local.sh` (same directory) and edit it. The
+# real file is gitignored, so your project names and color choices never get
+# committed or published.
+#
+# Map each project directory's basename to a color: hex (#rrggbb), a named
+# color (e.g. "red"), or colour0-255. Return empty to keep the theme default.
+accent_for() {
+  case "$1" in
+    my_work_app) printf '%s' "#ff966c" ;;  # orange
+    my_side_proj) printf '%s' "#c3e88d" ;; # green
+    *) printf '%s' "" ;;
+  esac
+}

--- a/tmux/.config/tmux/project-accent.tmux
+++ b/tmux/.config/tmux/project-accent.tmux
@@ -1,0 +1,28 @@
+# Per-project status accent
+#
+# Recolors the session-name pill in status-left per session, so each tmux
+# session (one per project, created via `tat`) shows a distinct color badge.
+#
+# Mechanism:
+#   - `@accent` is a user option holding the pill's background color. The
+#     status-left override below renders it; #{@accent} resolves per session.
+#   - The `session-created` hook runs scripts/project-accent.sh, which looks up
+#     the project (by directory basename) in its central map and sets @accent
+#     for that session.
+#   - Add/remove projects by editing the case map in scripts/project-accent.sh.
+#
+# NOTE: the status-left string below mirrors tokyonight_moon.tmux exactly,
+# except the literal #82aaff becomes #{@accent}. If you switch themes, re-derive
+# this line from the new theme — otherwise it imposes Moon's separator colors.
+
+# Default accent = TokyoNight Moon blue (matches the stock theme)
+set -g @accent "#82aaff"
+
+# status-left with the session-name pill driven by @accent
+set -g status-left "#[fg=#1b1d2b,bg=#{@accent},bold] #S #[fg=#{@accent},bg=#1e2030,nobold,nounderscore,noitalics]"
+
+# Apply the project color whenever a session is created...
+set-hook -g session-created 'run-shell "~/.config/tmux/scripts/project-accent.sh #{hook_session}"'
+
+# ...and backfill any sessions that already exist when this file is (re)sourced.
+run-shell "~/.config/tmux/scripts/project-accent.sh"

--- a/tmux/.config/tmux/project-accent.tmux
+++ b/tmux/.config/tmux/project-accent.tmux
@@ -7,9 +7,10 @@
 #   - `@accent` is a user option holding the pill's background color. The
 #     status-left override below renders it; #{@accent} resolves per session.
 #   - The `session-created` hook runs scripts/project-accent.sh, which looks up
-#     the project (by directory basename) in its central map and sets @accent
-#     for that session.
-#   - Add/remove projects by editing the case map in scripts/project-accent.sh.
+#     the project (by tmux session name) in the local map and sets @accent for
+#     that session.
+#   - Add/remove projects by editing the case map in project-accent.local.sh
+#     (your gitignored copy of project-accent.local.sh.example).
 #
 # NOTE: the status-left string below mirrors tokyonight_moon.tmux exactly,
 # except the literal #82aaff becomes #{@accent}. If you switch themes, re-derive

--- a/tmux/.config/tmux/project-accent.tmux
+++ b/tmux/.config/tmux/project-accent.tmux
@@ -1,26 +1,24 @@
 # Per-project status accent
 #
-# Recolors the session-name pill in status-left per session, so each tmux
-# session (one per project, created via `tat`) shows a distinct color badge.
+# Recolors the session-name pill (status-left) and the hostname pill
+# (status-right) per session, so each tmux session — one per project, created
+# via `tat` — shows a distinct color on both ends of the status bar.
 #
 # Mechanism:
-#   - `@accent` is a user option holding the pill's background color. The
-#     status-left override below renders it; #{@accent} resolves per session.
+#   - The theme (themes/tokyonight_moon.tmux) renders both pills from the
+#     `@accent` user option and sets the default, so @accent is the single knob
+#     that drives the accent color. Nothing here mirrors the theme's status
+#     strings.
 #   - The `session-created` hook runs scripts/project-accent.sh, which looks up
-#     the project (by tmux session name) in the local map and sets @accent for
-#     that session.
+#     the project (by tmux session name) in the local map and sets a
+#     session-level @accent. tmux resolves #{@accent} in each session's context,
+#     so a session's pills take its color; unmatched sessions fall back to the
+#     theme default.
 #   - Add/remove projects by editing the case map in project-accent.local.sh
 #     (your gitignored copy of project-accent.local.sh.example).
 #
-# NOTE: the status-left string below mirrors tokyonight_moon.tmux exactly,
-# except the literal #82aaff becomes #{@accent}. If you switch themes, re-derive
-# this line from the new theme — otherwise it imposes Moon's separator colors.
-
-# Default accent = TokyoNight Moon blue (matches the stock theme)
-set -g @accent "#82aaff"
-
-# status-left with the session-name pill driven by @accent
-set -g status-left "#[fg=#1b1d2b,bg=#{@accent},bold] #S #[fg=#{@accent},bg=#1e2030,nobold,nounderscore,noitalics]"
+# Switching themes: parameterize the new theme's pills with #{@accent} the same
+# way (see tokyonight_moon.tmux) — that is all this feature needs from a theme.
 
 # Apply the project color whenever a session is created...
 set-hook -g session-created 'run-shell "~/.config/tmux/scripts/project-accent.sh #{hook_session}"'

--- a/tmux/.config/tmux/scripts/project-accent.sh
+++ b/tmux/.config/tmux/scripts/project-accent.sh
@@ -27,10 +27,10 @@ local_map="${XDG_CONFIG_HOME:-${HOME}/.config}/tmux/project-accent.local.sh"
 [ -r "${local_map}" ] && . "${local_map}"
 
 apply_one() {
-  local session="$1" path color
-  path="$(tmux display-message -p -t "${session}" '#{session_path}' 2>/dev/null)" || return 0
-  [ -n "${path}" ] || return 0
-  color="$(accent_for "$(basename "${path}")")"
+  local session="$1" name color
+  name="$(tmux display-message -p -t "${session}" '#{session_name}' 2>/dev/null)" || return 0
+  [ -n "${name}" ] || return 0
+  color="$(accent_for "${name}")"
   [ -n "${color}" ] && tmux set-option -t "${session}" @accent "${color}"
   return 0
 }

--- a/tmux/.config/tmux/scripts/project-accent.sh
+++ b/tmux/.config/tmux/scripts/project-accent.sh
@@ -27,7 +27,7 @@ local_map="${XDG_CONFIG_HOME:-${HOME}/.config}/tmux/project-accent.local.sh"
 [ -r "${local_map}" ] && . "${local_map}"
 
 apply_one() {
-  local session="$1" name color
+  local session="$1" name color client
   name="$(tmux display-message -p -t "${session}" '#{session_name}' 2>/dev/null)" || return 0
   [ -n "${name}" ] || return 0
   color="$(accent_for "${name}")"
@@ -38,6 +38,14 @@ apply_one() {
     # default. Keeps re-runs idempotent after the map changes.
     tmux set-option -t "${session}" -u @accent
   fi
+  # set-option does not repaint the status bar. When a client is already attached
+  # (e.g. tmuxinator attaches before this async session-created hook runs), the
+  # bar would keep the default color until the next status-interval tick or a
+  # manual reload. Force a status redraw on the session's clients so the accent
+  # shows immediately.
+  while IFS= read -r client; do
+    [ -n "${client}" ] && tmux refresh-client -S -t "${client}" 2>/dev/null
+  done < <(tmux list-clients -t "${session}" -F '#{client_name}' 2>/dev/null)
   return 0
 }
 

--- a/tmux/.config/tmux/scripts/project-accent.sh
+++ b/tmux/.config/tmux/scripts/project-accent.sh
@@ -31,7 +31,13 @@ apply_one() {
   name="$(tmux display-message -p -t "${session}" '#{session_name}' 2>/dev/null)" || return 0
   [ -n "${name}" ] || return 0
   color="$(accent_for "${name}")"
-  [ -n "${color}" ] && tmux set-option -t "${session}" @accent "${color}"
+  if [ -n "${color}" ]; then
+    tmux set-option -t "${session}" @accent "${color}"
+  else
+    # No match: clear any session-level accent so it reverts to the theme
+    # default. Keeps re-runs idempotent after the map changes.
+    tmux set-option -t "${session}" -u @accent
+  fi
   return 0
 }
 

--- a/tmux/.config/tmux/scripts/project-accent.sh
+++ b/tmux/.config/tmux/scripts/project-accent.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Apply a per-project accent color to a tmux session's status bar.
+#
+# The accent is exposed to the theme as the `@accent` user option, which the
+# status-left pill (the `#S` session-name badge) renders as its background. See
+# project-accent.tmux for the wiring and the session-created hook.
+#
+# Usage:
+#   project-accent.sh <session-id>   # apply to one session (called by the hook)
+#   project-accent.sh                # backfill: apply to every current session
+#
+# The project -> color map is NOT defined here. It lives in a local, untracked
+# file so your project names and color choices stay on your machine:
+#
+#   ~/.config/tmux/project-accent.local.sh   (gitignored)
+#
+# Copy project-accent.local.sh.example to that path and edit it. Without the
+# local file, no session gets a custom accent (everything keeps the theme
+# default), so this feature is a no-op for anyone who forks these dotfiles.
+
+# Fallback: no per-project color until the local map redefines this.
+accent_for() { printf '%s' ""; }
+
+local_map="${XDG_CONFIG_HOME:-${HOME}/.config}/tmux/project-accent.local.sh"
+# shellcheck source=/dev/null
+[ -r "${local_map}" ] && . "${local_map}"
+
+apply_one() {
+  local session="$1" path color
+  path="$(tmux display-message -p -t "${session}" '#{session_path}' 2>/dev/null)" || return 0
+  [ -n "${path}" ] || return 0
+  color="$(accent_for "$(basename "${path}")")"
+  [ -n "${color}" ] && tmux set-option -t "${session}" @accent "${color}"
+  return 0
+}
+
+if [ "$#" -ge 1 ]; then
+  apply_one "$1"
+else
+  while IFS= read -r session; do
+    apply_one "${session}"
+  done < <(tmux list-sessions -F '#{session_id}' 2>/dev/null)
+fi

--- a/tmux/.config/tmux/themes/tokyonight_moon.tmux
+++ b/tmux/.config/tmux/themes/tokyonight_moon.tmux
@@ -1,5 +1,13 @@
 # TokyoNight colors for Tmux
 
+# Accent color for the status-bar pills (the session pill on the left and the
+# host pill on the right). Parameterized so the per-project feature can override
+# it per session via the @accent user option (see project-accent.tmux). The
+# default keeps the stock TokyoNight Moon blue, so this theme renders correctly
+# on its own. If you port these tweaks to another theme, parameterize that
+# theme's pills the same way.
+set -g @accent "#82aaff"
+
 set -g mode-style "fg=#82aaff,bg=#3b4261"
 
 set -g message-style "fg=#82aaff,bg=#3b4261"
@@ -19,10 +27,10 @@ set -g status-right-length "100"
 set -g status-left-style NONE
 set -g status-right-style NONE
 
-set -g status-left "#[fg=#1b1d2b,bg=#82aaff,bold] #S #[fg=#82aaff,bg=#1e2030,nobold,nounderscore,noitalics]"
-set -g status-right "#[fg=#1e2030,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#1e2030] #{prefix_highlight} #[fg=#3b4261,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#3b4261] %Y-%m-%d  %I:%M %p #[fg=#82aaff,bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#1b1d2b,bg=#82aaff,bold] #h "
+set -g status-left "#[fg=#1b1d2b,bg=#{@accent},bold] #S #[fg=#{@accent},bg=#1e2030,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#1e2030,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#1e2030] #{prefix_highlight} #[fg=#3b4261,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#3b4261] %Y-%m-%d  %I:%M %p #[fg=#{@accent},bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#1b1d2b,bg=#{@accent},bold] #h "
 if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
-  set -g status-right "#[fg=#1e2030,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#1e2030] #{prefix_highlight} #[fg=#3b4261,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#3b4261] %Y-%m-%d  %H:%M #[fg=#82aaff,bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#1b1d2b,bg=#82aaff,bold] #h "
+  set -g status-right "#[fg=#1e2030,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#1e2030] #{prefix_highlight} #[fg=#3b4261,bg=#1e2030,nobold,nounderscore,noitalics]#[fg=#82aaff,bg=#3b4261] %Y-%m-%d  %H:%M #[fg=#{@accent},bg=#3b4261,nobold,nounderscore,noitalics]#[fg=#1b1d2b,bg=#{@accent},bold] #h "
 }
 
 setw -g window-status-activity-style "underscore,fg=#828bb8,bg=#1e2030"

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -105,6 +105,9 @@ set -g status-position top
 
 source-file $HOME/.config/tmux/themes/tokyonight_moon.tmux
 
+# Per-project status accent (recolors the session-name pill per project)
+source-file $HOME/.config/tmux/project-accent.tmux
+
 # }}}
 
 # Tmux Plugin Manager (TPM) {{{


### PR DESCRIPTION
## Summary

Color-codes each tmux session's status bar per project so simultaneously-running projects are easy to tell apart at a glance. Each project gets a distinct accent color on **both ends of the status bar** — the session-name "pill" on the left and the hostname pill on the right — regardless of how the session is launched (`tat`, `tmuxinator`, plain `new-session`). Sessions without a mapping keep the theme's default blue, so the feature is a no-op until you opt in — and a no-op for anyone forking these dotfiles.

## How it works

- `tmux/.config/tmux/themes/tokyonight_moon.tmux` — the theme is parameterized: it sets a default `@accent` user option (Moon blue `#82aaff`) and renders both status-bar pills (`status-left` and both `status-right` clock variants) from `#{@accent}`. This makes `@accent` the single knob that drives the accent, and the theme still renders correctly standalone.
- `tmux/.config/tmux/project-accent.tmux` — registers the `session-created` hook and backfills existing sessions when sourced. It no longer touches the status strings; all rendering lives in the theme.
- `tmux/.config/tmux/scripts/project-accent.sh` — sources the local color map, looks up a color by **tmux session name**, and sets `@accent` for the session (or clears it when there's no match). After applying, it forces a status redraw so the color appears immediately. Runs in single-session mode (from the hook) or all-sessions mode (backfill).
- `tmux/.config/tmux/project-accent.local.sh.example` — template for the `accent_for` map. The real `project-accent.local.sh` is gitignored, so project names and color choices stay local.
- `tmux/.config/tmux/tmux.conf` — sources the feature right after the theme.

## Key design decisions

- **Privacy first.** The session → color map lives in a gitignored local file. Without it, `accent_for` falls back to empty and nothing is recolored.
- **`@accent` is the single source of truth.** Rather than mirroring the theme's status strings into the feature file, the theme itself renders both pills from `#{@accent}` with a sensible default; `project-accent.tmux` only sets the option per session. This keeps duplication out of the feature and makes the accent trivially extensible. Switching themes means parameterizing the new theme's pills the same way — documented in both files.
- **Both ends of the bar.** Coloring the far-right hostname pill in addition to the left session pill puts the project color on both sides — easy to catch at a glance even when the terminal sits off to one side of a multi-monitor setup. The text segments (date/time, active window) keep the theme blue for readability.
- **Keyed on session name, not directory path.** Session names are unique per tmux server, match what the status pill shows, and let two checkouts that share a directory basename (e.g. two `bible_first_online` clones mapped as `bfo1`/`bfo2`) still get distinct colors. With `tat`, the session name is the directory's basename with dots converted to dashes.
- **Self-healing.** A session that no longer matches the map has its accent cleared (reverting to the theme default), so editing the map and re-running reconciles every session — no stale colors left behind.
- **Immediate repaint on attach.** The `session-created` hook runs asynchronously, so a launcher that attaches a client right after creating the session (tmuxinator) would otherwise show the default color until the next `status-interval` tick or a manual reload. The script forces a `refresh-client -S` after applying the accent to close that race.

## Documentation

Adds a "Per-project tmux accent" subsection to the README covering enablement, color formats, the session-name keying convention (including the dots-to-dashes note), and the both-pills coloring.

## Testing

- `./scripts/lint-shell` and `markdownlint-cli2` — pass.
- Verified both pills render `#{@accent}` per session across mapped and unmapped sessions, and across both `status-right` clock variants (12h/24h).
- Validated session-name keying, self-healing reconcile, and immediate coloring against live sessions — including a real `tmuxinator` launch showing the accent on attach.
