### PR TITLE
fix(tmux): background the project-accent session-created hook

### DIFF
--- a/tmux/.config/tmux/project-accent.tmux
+++ b/tmux/.config/tmux/project-accent.tmux
@@ -20,8 +20,12 @@
 # Switching themes: parameterize the new theme's pills with #{@accent} the same
 # way (see tokyonight_moon.tmux) — that is all this feature needs from a theme.
 
-# Apply the project color whenever a session is created...
-set-hook -g session-created 'run-shell "~/.config/tmux/scripts/project-accent.sh #{hook_session}"'
+# Apply the project color whenever a session is created. Background the hook
+# (-b) so it stays off tmux's command-queue critical path: a foreground
+# run-shell here blocks the server while tmuxinator spawns a project's panes,
+# adding shell-startup contention. The script's own `refresh-client -S` still
+# paints the accent right away, so backgrounding costs no immediacy.
+set-hook -g session-created 'run-shell -b "~/.config/tmux/scripts/project-accent.sh #{hook_session}"'
 
 # ...and backfill any sessions that already exist when this file is (re)sourced.
 run-shell "~/.config/tmux/scripts/project-accent.sh"


### PR DESCRIPTION
## Summary

- The per-project accent feature (#207) installed its `session-created` hook with a **foreground** `run-shell`, which blocks tmux's command queue while the script forks `bash` plus several tmux subprocesses — landing on the critical path exactly as `tmuxinator start` spawns a project's 4–5 pane shells, adding shell-startup contention.
- This backgrounds the hook with `run-shell -b` so the accent work runs off the command-queue critical path. The script's own `refresh-client -S` still repaints the bar, so the accent continues to appear immediately on new sessions.

## Changes

- `tmux/.config/tmux/project-accent.tmux`: add `-b` to the `session-created` hook's `run-shell`, and expand the inline comment to explain why it's backgrounded.

## Testing

- [x] Isolated tmux server (`-L accent-test`, separate from live sessions): hook definition is now `run-shell -b …`; a mapped session (`bfo1`) receives `@accent = #93db29` via the backgrounded hook in ~50–100ms — no paint regression; an unmapped session falls back to the theme default.
- [x] `./scripts/lint-shell` — 42 scripts pass.
- [x] `./scripts/run-tests` — 79 bats tests pass.
- [ ] Best-effort real-world check: a morning of sequentially starting ~7 multi-pane sessions no longer produces `job-queue` timeout spam (validated over time in actual use, not from a single run).

## Notes

- **Scope:** primary change only. Skipped the optional "skip the `refresh-client` loop when unmapped" tweak — the local accent map covers every session actually run, so the unmapped branch never fires; it would add a conditional plus a stale-paint edge case for no real benefit. Left the config-source backfill (line 27) in the foreground — out of scope and off the session-creation critical path.
- **Confidence:** this is the *amplifier* fix, not a proven root-cause fix. It removes the startup contention #207 introduced; whether it fully ends the `job-queue` spam can only be confirmed across real launches. If it recurs, next steps are the `abbr-queue-clear` helper (#209) and instrumenting with `JOB_QUEUE_DEBUG=1`.

Closes #208
