### PR TITLE
feat(autopilot): /autopilot-triage queue-vetting skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Custom [skills][agent-skills] provide structured workflows for the full developm
 | ----- | ------- |
 | `/autopilot` | Carry one well-scoped issue through the full dev loop autonomously, to a review-ready PR (or merge for small reversible changes) |
 | `/autopilot-batch` | Fan out a queue of issues to parallel worktree subagents, each running `/autopilot`, with an Opus gating review per PR |
+| `/autopilot-triage` | Vet open issues for autonomous resolution and queue the qualifying ones for `/autopilot-batch` |
 | `/bootstrap-prd` | Scaffold PRD-driven development infrastructure into a new project |
 | `/checkpoint` | Quick status update — what's done, in progress, and blocked |
 | `/create-pr` | Create a PR with auto-linked issues and formatted description |

--- a/claude/.claude/cheatsheet.md
+++ b/claude/.claude/cheatsheet.md
@@ -61,6 +61,7 @@ Changes apply live without a restart. If Neovim ever swallows `Ctrl+↑`/`Ctrl+�
 | `/create-pr` | Create a PR with auto-generated description and issue linking (inferred from branch name) |
 | `/simplify` | Post-implementation code review — run before creating a PR |
 | `/autopilot 123 --to pr` | Carry one issue through the whole loop autonomously to a review-ready PR (or `--to merge` for small reversible changes) |
+| `/autopilot-triage` | Start-of-day: vet open issues and queue the autonomy-ready ones (`autopilot-queued`) |
 | `/autopilot-batch` | Fan out the `autopilot-queued` queue — one parallel worktree subagent per issue, Opus-reviewed |
 
 Custom skills live in `claude/.claude/skills/`; `/simplify` and `/code-review` are built-in Claude Code skills. Type `/` to browse the full list including PRD-specific skills (`/bootstrap-prd`, `/plan-phase`, `/debrief`, etc.).

--- a/claude/.claude/docs/prd-workflow/spec-driven-development.md
+++ b/claude/.claude/docs/prd-workflow/spec-driven-development.md
@@ -273,7 +273,8 @@ This section maps every skill to its place in the development cycle. Think of it
 | `/bootstrap-prd` | Scaffold PRD structure for a new project | Once per project |
 | `/prd-view` | Render a PRD file as a rich HTML reading view (Dashboard style) for engaged reading and vetting; Markdown stays authoritative, the HTML is ephemeral | Ad-hoc (reading / vetting a spec) |
 | `/plan-phase` | Create GitHub issues from a PRD phase | Once per phase |
-| `/autopilot-batch` | Fan out a queue of issues to parallel worktree subagents, each running `/autopilot` | Per sprint (optional) |
+| `/autopilot-triage` | Vet open issues for autonomous resolution; queue the qualifying ones (`autopilot-queued`) | Per sprint (optional) |
+| `/autopilot-batch` | Fan out the queued issues to parallel worktree subagents, each running `/autopilot` | Per sprint (optional) |
 | `/resolve-issue` | Implement an issue end-to-end; planning checkpoint scales to complexity | Per issue |
 | `/simplify` | Review changed code for reuse, quality, efficiency | Pre-PR |
 | `/drift-check` | Deviation check against the spec | Pre-PR |
@@ -358,7 +359,7 @@ Published walkthroughs and QA handoffs (see "Publishing artifacts to remote test
 At the start of each phase:
 
 1. **`/plan-phase`** — Read the relevant PRD files, create GitHub issues with acceptance criteria and implementation order. This is a planning-only skill — no code is written.
-2. **`/autopilot-batch`** _(optional)_ — If the phase contains a batch of small, independent, well-scoped issues (common for chore or fix batches), fan them out: one background worktree subagent per queued issue, each running `/autopilot` to a review-ready PR (Sonnet builds, Opus reviews). Replaces the old manual per-worktree, terminal-per-issue handoff.
+2. **`/autopilot-triage` → `/autopilot-batch`** _(optional)_ — If the phase contains a batch of small, independent, well-scoped issues (common for chore or fix batches), vet them with `/autopilot-triage` (queues the autonomy-ready ones after your confirm), then fan them out with `/autopilot-batch`: one background worktree subagent per queued issue, each running `/autopilot` to a review-ready PR (Sonnet builds, Opus reviews). Replaces the old manual per-worktree, terminal-per-issue handoff.
 
 ### Phase boundary
 

--- a/claude/.claude/skills/autopilot-triage/SKILL.md
+++ b/claude/.claude/skills/autopilot-triage/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: autopilot-triage
+description: Vet open issues for autonomous resolution and queue the qualifying ones with the autopilot-queued label — the start-of-day "fill the queue" half of the triage → run split.
+argument-hint: "[label-or-filter]"
+---
+
+# Autopilot Triage
+
+Vet a pool of open issues against the autonomy rubric and, after your confirmation, tag the ones that qualify with the `autopilot-queued` label. `/autopilot-batch` later reads that label and runs the batch. This is the **vet** half of the triage → run split; the two are decoupled on purpose — triage once (cheap, start-of-day), run the batch whenever and from wherever.
+
+The label is **membership only**: it means "vetted and pending," nothing more. Build model and tier are decided at run time (model by rubric, tier by your `--merge` opt-in), never encoded in the label.
+
+## Where this runs
+
+Run from the **target application repository** — you need the issues _and_ the code, because vetting scope means looking at what a fix would actually touch. Triage is read-only except for the label writes it makes _after_ your confirm.
+
+## Arguments
+
+- **(no args)** — vet all open issues.
+- **`[label-or-filter]`** — narrow the candidate pool, e.g. a phase label or `chore` / `fix`. Passed through to `gh issue list --label`.
+
+## The autonomy rubric
+
+An issue **qualifies** for autopilot when all hold:
+
+- **Complete spec** — clear acceptance criteria; you could hand it off with no back-and-forth.
+- **Bounded scope** — a few files, one subsystem, a known pattern to follow (the positive exemplar: a "localize these hardcoded strings" i18n issue).
+- **No product / UX / design decision** — nothing that needs your judgment about _what_ to build.
+- **Testable** — its resolution can be proven by the suite (or a targeted inline check).
+
+An issue is **disqualified** when it trips any of `/autopilot`'s own escape-hatch triggers — the same guardrails, applied _before_ the run instead of during it:
+
+- a new DB column / migration, a changed model association, an altered public route, a new dependency, or an event-status-lifecycle change;
+- a thin or ambiguous spec, or one that conflicts with the code;
+- multiple subsystems, a real design choice, or anything you'd want to review mid-flight.
+
+When a candidate is borderline, **disqualify it** — a false negative costs you one manual issue; a false positive burns an unattended run on something that should have stopped. State a one-line reason for every skip; those reasons are useful signal.
+
+For each qualifying issue, also note — as a **preview**, not a commitment:
+
+- **Build model** — Opus for data-model / security / ambiguous / cross-cutting; Sonnet for bounded pattern-work (i18n / views / config / a single test / CRUD / docs). `/autopilot-batch` re-derives this at run time from the same rubric; your preview is so you can eyeball and adjust before the run.
+- **Merge-tier candidate?** — flag issues that look safe for `--to merge` (confined to config / locales / views / copy; no migration / route / dependency). These are _suggestions_ you opt into with `--merge` at run time; the batch defaults everything to `--to pr`.
+
+## Your task
+
+### Step 1 — Reconcile (self-healing)
+
+Before proposing anything, clean the existing queue so an interrupted prior run can't leave stale membership:
+
+- `gh issue list --label autopilot-queued --state open --json number,title`.
+- For each, check whether a PR already exists for it — a branch named for the issue:
+
+  ```bash
+  gh pr list --state all --json number,headRefName,state \
+    --jq '.[] | select(.headRefName | test("gh-<n>-"))'
+  ```
+
+- If a PR exists (open or merged), the issue is in-flight or done, not pending — strip the label: `gh issue edit <n> --remove-label autopilot-queued`.
+- Report what was reconciled (or "queue clean — nothing to reconcile").
+
+### Step 2 — Gather candidates
+
+- `gh issue list --state open [--label <filter>] --json number,title,labels,body`.
+- Drop any already labeled `autopilot-queued` (already vetted) or already carrying a PR (from Step 1's check).
+
+### Step 3 — Vet
+
+Assess each candidate against the rubric — read the issue body and, where scope is unclear, the code a fix would touch. Assign a verdict (queue / skip), a one-line why, and for queue candidates the model preview + merge-tier flag.
+
+### Step 4 — Present + CONFIRM GATE
+
+Present the triage table — proposed queue and skips together, so the exclusions are visible:
+
+```text
+Queue:
+  #851  Sonnet  pr     localize checkout flash messages — complete spec, i18n pattern
+  #863  Sonnet  merge? copy tweak on the about page — config/copy only, no code paths
+  #847  Opus    pr     recompute shipment weight rounding — bounded but touches money math
+
+Skip:
+  #870  needs a data-model decision (new column not in the schema)
+  #872  spec ambiguous — two conflicting acceptance criteria
+```
+
+**CONFIRM GATE:** This is the human gate the lifecycle requires — the label is applied **only after you confirm**. Present the proposed queue and wait. You may trim, add, or adjust a model call. Nothing is labeled before you say go.
+
+### Step 5 — Apply the label
+
+Only after confirmation:
+
+- Ensure the label exists (first run bootstraps it): `gh label list` and look for `autopilot-queued`; if absent, create it:
+
+  ```bash
+  gh label create autopilot-queued \
+    --description "Vetted by /autopilot-triage; pending an /autopilot-batch run" \
+    --color 5319e7
+  ```
+
+- For each confirmed issue: `gh issue edit <n> --add-label autopilot-queued`.
+
+### Step 6 — Report + handoff
+
+Summarize: how many were queued (list + model preview + which are merge-tier candidates), how many reconciled/removed, how many skipped (with reasons). Then the handoff:
+
+> Queue ready — _N_ issues. Run it from this repo with `/autopilot-batch`. To authorize merge for the flagged candidates, add `--merge <#,#>`.
+
+## Important
+
+- **The confirm gate is a hard stop.** The label is never applied speculatively — only issues you approve get queued (lifecycle step 1).
+- **Membership only.** The label encodes neither model nor tier; those are run-time decisions. Do not add per-issue tier/model labels.
+- **Reconcile first, always.** Every run self-heals the queue before proposing, so a crashed or interrupted prior run leaves no stale membership.
+- **Decoupled by design.** Triage and run are separate sessions on purpose — vet cheaply now, run the batch later / from anywhere. Do not fold the batch run into this skill.
+- **When borderline, skip.** Autopilot's value is unattended throughput on issues that genuinely don't need you; a wrongly-queued issue that should have stopped defeats that.


### PR DESCRIPTION
## Summary

Phase 2 **§2 (triage queue)** — the *vet* half of the triage → run split, completing the autopilot family. `/autopilot-triage` scans open issues, vets each against the autonomy rubric, and — after a hard human confirm gate — tags the qualifying ones with the `autopilot-queued` label that `/autopilot-batch` consumes.

> **Stacked on #215.** Base is `feat/autopilot-batch-fanout` so the shared README/cheatsheet/handbook edits stay conflict-free. GitHub will retarget this to `master` when #215 merges. Review/merge #215 first.

## What's here

**New skill — `/autopilot-triage`** (`claude/.claude/skills/autopilot-triage/SKILL.md`)

- **Autonomy rubric** — qualifies complete-spec, bounded, no-product-decision, testable issues; disqualifies anything tripping `/autopilot`'s own escape-hatch triggers (migration, model association, route/dep change, lifecycle change, ambiguous spec). Borderline → skip, with a one-line reason.
- **Confirm gate** — the label is applied *only* after you approve the proposed queue.
- **Lifecycle contract enforced** (label = membership only):
  - Applied only post-confirm, never speculatively.
  - **Self-healing:** each run first reconciles — strips the label from any issue that already has a PR (branch matching `gh-<n>-`), covering an interrupted prior run.
  - First run bootstraps the label (`gh label create autopilot-queued`).

**Docs** — add `/autopilot-triage` to the README + cheatsheet skill tables and the handbook skill map; update the phase-planning step to the `triage → batch` pairing.

## How the model/tier handoff works (decision #3 from #215)

The label stays a pure workflow-state membership marker. Triage **previews** each issue's build model (the same rubric `/autopilot-batch` re-derives at run time) and **flags** merge-tier candidates — but neither is encoded in the label. Tier is the batch's `--merge` opt-in; model is re-derived at fan-out. So triage and run stay decoupled (vet now, run later/elsewhere) without persisting per-issue state on the issue.

## Testing

- `pre-commit run markdownlint-cli2` passes on all changed markdown.
- Reconcile/label commands are grounded in the existing `gh-<n>-` branch convention.
- End-to-end validation (triage → `autopilot-queued` → `/autopilot-batch` fan-out) against the live app repo is the next step once #215 + this land.

Closes #212 (completes Phase 2 — §1 fan-out, §2 triage, §3 model delegation). A first real batch run remains as a usage-validation step, not a code deliverable.
