### PR TITLE
docs(prd): make /walkthrough on-demand instead of a routine PR-loop step

### DIFF
--- a/claude/.claude/docs/prd-workflow/spec-driven-development.md
+++ b/claude/.claude/docs/prd-workflow/spec-driven-development.md
@@ -318,28 +318,27 @@ This is where most development time is spent. One pass through this cycle produc
 6. Verify
    └─ /verify                  (agent drives the running app — user-facing PRs only)
 
-7. Walkthrough
-   └─ /walkthrough             (human browser pre-flight — user-facing PRs only)
-
-8. Review
+7. Review
    └─ /code-review             (correctness + cleanups; built-in /review for an existing PR by number)
 
-9. Publish walkthrough
-   └─ /walkthrough --publish   (renders HTML, uploads to project's QA host, posts PR comment with link)
-
-10. Merge
+8. Merge
    └─ /merge-pr                (squash merge, clean up, pull the default branch)
 ```
 
 Steps 3 and 4 are the pre-PR quality gates. `/simplify` looks at the code itself; `/drift-check` looks at the code's relationship to the spec. Together they catch both implementation quality issues and specification drift before the PR is created.
 
-Step 6 is `/verify` (user-facing PRs only): the _agent_ drives the running app and reports what it observed, confirming the change actually works and catching runtime bugs before review. It complements the walkthrough rather than duplicating it — `/verify` is agent-driven (the agent runs the feature and judges the output), while `/walkthrough` is human-driven (the agent writes a checklist for the orchestrator to exercise). The two catch different classes of issue (mechanics/regressions vs. UX/visual judgment), so run both for substantive user-facing work; skip both when there is no runnable user-facing surface.
+Step 6 is `/verify` (user-facing PRs only): the _agent_ drives the running app and reports what it observed, confirming the change actually works and catching runtime bugs before review. It is the loop's single routine user-facing check — the agent runs the feature and judges the output, so a change that does not actually work is caught before review attention is spent on the code. Run it for substantive user-facing work; skip it when there is no runnable user-facing surface.
 
-Steps 7 and 9 are the walkthrough's two slots, both conditional on the PR having user-facing changes. At step 7, `/walkthrough` produces a throwaway browser checklist (Markdown, in `tmp/`) so the orchestrator can exercise the feature before spending review attention on the code; it is re-run as fixes land. At step 9, once the code is final, `/walkthrough --publish` renders a rich HTML version, uploads it to the project's QA host (when one is declared — see "Publishing artifacts to remote testers" below), and posts a PR comment linking to it so the QA tester can follow it after deploy. For PRs with no user-facing surface the skill reports that and exits at either slot.
+**Walkthroughs are on demand, not routine.** `/walkthrough` writes a browser checklist (Markdown, in `tmp/`) for a _human_ to exercise, and `/walkthrough --publish` renders a rich HTML version, uploads it to the project's QA host (see "Publishing artifacts to remote testers" below), and posts a PR comment linking to it. Neither is a step in the default loop. `/verify` already drives the running app on every user-facing PR, so for most changes a walkthrough re-checks by hand what `/verify` just demonstrated live — a tax rather than a gate, and one that gets skipped in practice. Reach for it when the routine checks are genuinely not enough:
 
-Step 10 closes the loop. `/merge-pr` encapsulates the merge preferences (squash merge by default), cleans up the feature branch, and pulls the latest changes on the default branch — ensuring a consistent end state after every PR.
+- **A complex or high-risk feature** — you want to drive the UI yourself, exercising judgment (UX, visual polish, feel) that an agent's report does not capture.
+- **A project with a non-technical QA tester downstream** — someone who is not in the code and needs a reproduction guide to follow after deploy. This is the case the walkthrough was designed for. Such a project should make both slots routine — `/walkthrough` before review, `/walkthrough --publish` before merge — and say so in its own `CLAUDE.md`, so the choice is explicit rather than assumed.
 
-**Local CI sign-off as the gate.** Some projects don't run CI on pull requests — e.g. GitHub Actions fires only on push to `main` — and instead gate merges on a local `bin/ci` run that records a `gh signoff` status on the branch. Two consequences for ordering: (1) the sign-off attaches to the _pushed_ branch, so the `bin/ci` gate runs **after** `/create-pr`, never before it; and (2) the sign-off must cover the exact commit that merges, so re-run `bin/ci` after any walkthrough or review fix. Don't add a separate pre-PR `bin/ci` pass — `/resolve-issue` and `/simplify` already validate locally, and a pre-PR run can't sign off anyway.
+If the "tester" is a second developer running their own Claude sessions, they are not that reader, and published walkthroughs go unread. Leave both on demand.
+
+Step 8 closes the loop. `/merge-pr` encapsulates the merge preferences (squash merge by default), cleans up the feature branch, and pulls the latest changes on the default branch — ensuring a consistent end state after every PR.
+
+**Local CI sign-off as the gate.** Some projects don't run CI on pull requests — e.g. GitHub Actions fires only on push to `main` — and instead gate merges on a local `bin/ci` run that records a `gh signoff` status on the branch. Two consequences for ordering: (1) the sign-off attaches to the _pushed_ branch, so the `bin/ci` gate runs **after** `/create-pr`, never before it; and (2) the sign-off must cover the exact commit that merges, so re-run `bin/ci` after any review or QA fix. Don't add a separate pre-PR `bin/ci` pass — `/resolve-issue` and `/simplify` already validate locally, and a pre-PR run can't sign off anyway.
 
 ### The QA feedback loop
 

--- a/claude/.claude/docs/prd-workflow/spec-driven-development.md
+++ b/claude/.claude/docs/prd-workflow/spec-driven-development.md
@@ -281,7 +281,7 @@ This section maps every skill to its place in the development cycle. Think of it
 | `/drift-check` | Deviation check against the spec | Pre-PR |
 | `/create-pr` | Create PR with issue linking and ROADMAP update | Per issue |
 | `/verify` | Drive the running app end-to-end to confirm a change works (agent-driven; built-in) | Pre-review (user-facing PRs) |
-| `/walkthrough` | Generate a browser walkthrough of user-facing changes; `--publish` renders HTML, uploads to the project's QA host (when configured), and posts a PR comment with the link | Pre-review, then pre-merge (user-facing PRs) |
+| `/walkthrough` | Generate a browser walkthrough of user-facing changes; `--publish` renders HTML, uploads to the project's QA host (when configured), and posts a PR comment with the link | On demand (complex features; projects with a non-technical tester) |
 | `/code-review` | Review the diff for correctness bugs and cleanups at a chosen effort level (built-in; `/review` for an existing PR by number) | Pre-merge |
 | `/merge-pr` | Squash merge, clean up branch, pull the default branch | Post-review |
 | `/qa-handoff` | Generate a hands-on QA testing guide as a self-contained HTML page; `--publish` uploads it to the project's QA host | Per feature (when needed) |
@@ -413,7 +413,7 @@ Skills shift in importance as the project matures (see §6):
 | `/simplify` | Pre-PR | Pre-PR | Pre-PR |
 | `/drift-check` | **Critical** | Important | Light (living docs) |
 | `/create-pr` | **Always** | **Always** | **Always** |
-| `/walkthrough` | User-facing PRs | User-facing PRs | User-facing PRs |
+| `/walkthrough` | On demand | On demand | On demand |
 | `/code-review` | Pre-merge | Pre-merge | Pre-merge |
 | `/merge-pr` | **Always** | **Always** | **Always** |
 | `/qa-handoff` | Major features | Key changes | Rare |

--- a/claude/.claude/docs/prd-workflow/templates/CLAUDE.md
+++ b/claude/.claude/docs/prd-workflow/templates/CLAUDE.md
@@ -57,6 +57,8 @@ QA — walkthroughs (`/walkthrough`) and `/verify` runs — is gated on launch s
 
 Flip this flag to **POST-LAUNCH** as part of the launch cutover. The `/walkthrough` skill reads it: pre-launch it offers the production-testing callout; post-launch it emits the local-dev-only warning instead.
 
+**Walkthroughs are on demand.** `/verify` is the routine user-facing check in the PR loop; `/walkthrough` and `/walkthrough --publish` are not. Invoke them when a feature is complex enough to warrant a human browser pass, or when this project has a QA tester who is not in the code and needs a reproduction guide to follow after deploy. A project with such a tester should make both routine — `/walkthrough` before review, `--publish` before merge — and record that decision here, so it is an explicit choice rather than a silent default. If the tester is another developer running their own Claude sessions, leave both on demand: a published walkthrough has no reader. However a walkthrough is invoked, the launch-status gate above still binds.
+
 ## QA Publish Target
 
 <!--


### PR DESCRIPTION
## Summary

- Removes `/walkthrough` and `/walkthrough --publish` from the routine PR pipeline, renumbering the cycle from ten steps to eight. `/verify` becomes the single routine user-facing check.
- Keeps `/walkthrough` fully available on demand, and — importantly — keeps the knowledge the routine step encoded: both docs now name the case it was designed for (a QA tester who is not in the code) and say such a project should opt back into making it routine.
- The `/walkthrough` skill itself is untouched. Only its place in the documented default loop changes.

## Changes

**`spec-driven-development.md`**

- PR-cycle diagram: dropped step 7 (Walkthrough) and step 9 (Publish walkthrough); renumbered to eight steps.
- Rewrote the three paragraphs that referenced the removed steps — the `/verify` paragraph (no longer framed as "complements the walkthrough"), the "two slots" paragraph (now an on-demand note with the two cases that warrant reaching for it), and the local-CI sign-off line ("after any walkthrough or review fix" → "after any review or QA fix").
- Skill map: `/walkthrough`'s **When** column now reads on-demand rather than "Pre-review, then pre-merge".
- Role matrix: `/walkthrough` reads "On demand" across all three maturity columns.

**`templates/CLAUDE.md`**

- § QA Testing Policy now states that `/verify` is the routine user-facing check while `/walkthrough` / `--publish` are on demand, and names the case that should opt back into routine — recording that decision in the project's own `CLAUDE.md` so it is an explicit choice rather than a silent default.

## Testing

- [x] `markdownlint-cli2` passes (ran via pre-commit on every commit)
- [x] Dangling-reference sweep across `claude/.claude/docs/` for `step 7|9|10`, "pre-review, then pre-merge", "complements the walkthrough", and "walkthrough or review fix" — all clean
- [x] Launch-status gate verified intact (see Notes)

## Notes

**The issue's file attribution was off, and one acceptance criterion is satisfied by inspection rather than by edit.** Issue #229 asks to strip a numbered pipeline from `templates/CLAUDE.md`. That file has no pipeline and never did — `git log -S "Walkthrough"` on it returns nothing. Of the three cross-references the issue named, two live in `spec-driven-development.md` and the third ("before Verify and Walkthrough") does not exist anywhere in this repo; it appears to describe ComixDistro's own project `CLAUDE.md`, which carries its own extended loop. The intent of the issue was right, so each criterion was routed to the file that actually holds the thing. AC1 is therefore ticked on the strength of a clean dangling-reference sweep, not an edit. Detail in the issue comment.

**The pre-launch/post-launch QA gate survives strictly.** The change to `templates/CLAUDE.md` is purely additive — `git diff master..HEAD` on that file shows zero removed or modified lines — so the gate is byte-for-byte intact and still binds whenever a walkthrough is run, however it is invoked.

Closes #229
Refs euroteamoutreach/comix_distro#911
