### PR TITLE
chore(zsh): audit the shell config against the agent-safety rule and guard the alias layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,22 @@ This repo overrides the global PR-first default. Small changes — config tweaks
 - Starship prompt for consistent, informative shell prompting
 - Smart git functions with automatic branch detection (gpum, grbm, gcom, gbrm)
 
+#### Human vs. Agent Shells
+
+This config serves humans at an interactive prompt and coding agents in non-interactive shells, which want opposite things. The rule:
+
+> If it is for humans — pretty output, confirmation prompts, muscle memory — make it an **abbreviation**.
+> If it must be an **alias**, it will reach agents, so it has to be non-interactive, plain, and parse-stable.
+
+Abbreviations cannot reach agents (expansion needs ZLE), but aliases do — Claude Code snapshots the shell and replays it into every tool call. So the last line of `.zshrc` drops the alias layer in non-interactive shells (`[[ -o interactive ]] || unalias -a`). It must stay last, since the exa plugin defines `ls`/`ll`/`la`/`tree` of its own. Functions and environment are untouched.
+
+Two consequences worth knowing when working in this repo:
+
+- **Add human conveniences as abbreviations, not aliases.** Anything with a confirmation prompt or decorated output belongs in `abbreviations.zsh`.
+- **A shell-config fix does not reach a running agent session.** Snapshots are cached and replayed, so an in-flight session keeps the old aliases until it restarts.
+
+→ See `zsh/README.md` "Agents and the Alias Layer" for the full reasoning, the evidence behind the guard, and the optional-value flag trap.
+
 ### Stow-based Symlink Management
 
 - GNU Stow creates symlinks from dotfiles directory to `$HOME`

--- a/tests/shell_safety/test_agent_safety.bats
+++ b/tests/shell_safety/test_agent_safety.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+
+# Tests for the agent-safety rule (see zsh/README.md "Agents and the alias layer").
+#
+# Aliases are the only layer of this config that reaches a coding agent, so
+# .zshrc drops them in non-interactive shells. These tests cover the two halves
+# of that: the guard is present and correctly placed, and zsh actually behaves
+# the way the guard assumes.
+#
+# The behavioural tests use a synthetic rc file rather than the real ~/.zshrc.
+# CI installs zsh but never stows the dotfiles or installs zap/eza, so sourcing
+# the real file there proves nothing. A synthetic rc tests the mechanism itself
+# on the same zsh the user runs.
+
+load '../helpers/common.bash'
+load '../helpers/shell_helpers.bash'
+
+setup() {
+  require_command zsh
+  require_file "${DOTFILES}/zsh/.zshrc"
+}
+
+@test "zshrc drops aliases in non-interactive shells" {
+  run grep -c '^\[\[ -o interactive \]\] || unalias -a$' "${DOTFILES}/zsh/.zshrc"
+  assert_equals "1" "${output}" "the alias guard should appear exactly once"
+}
+
+@test "the alias guard is the last executable line in zshrc" {
+  # Placement is load-bearing: aliases arrive from plugins.zsh (the exa plugin
+  # defines ls/ll/la/tree), aliases.zsh, and .zshrc.local. A guard that runs
+  # before any of them leaves those aliases exposed to agents.
+  local last
+  last=$(grep -vE '^\s*(#|$)' "${DOTFILES}/zsh/.zshrc" | tail -1)
+  assert_equals '[[ -o interactive ]] || unalias -a' "${last}"
+}
+
+@test "a non-interactive zsh drops guarded aliases" {
+  local rc
+  rc=$(create_temp_file)
+  cat >"${rc}" <<'EOF'
+alias ls='eza --icons'
+alias vim='nvim'
+[[ -o interactive ]] || unalias -a
+EOF
+
+  run zsh -c "source '${rc}'; alias | wc -l | tr -d ' '"
+  assert_equals "0" "${output}" "an agent shell should see no aliases"
+  rm -f "${rc}"
+}
+
+@test "an interactive zsh keeps guarded aliases" {
+  local rc
+  rc=$(create_temp_file)
+  cat >"${rc}" <<'EOF'
+alias test_guard_canary='echo canary'
+[[ -o interactive ]] || unalias -a
+EOF
+
+  run zsh -i -c "source '${rc}'; alias test_guard_canary"
+  assert_contains "${output}" "canary" "a human shell should keep its aliases"
+  rm -f "${rc}"
+}
+
+@test "the guard leaves functions intact for agents" {
+  # Only the alias layer is swept. Functions are how gcom/gpum/grbm reach
+  # agents, so unalias -a must not disturb them.
+  local rc
+  rc=$(create_temp_file)
+  cat >"${rc}" <<'EOF'
+alias ls='eza --icons'
+function agent_visible_fn() { echo "still here"; }
+[[ -o interactive ]] || unalias -a
+EOF
+
+  run zsh -c "source '${rc}'; agent_visible_fn"
+  assert_equals "still here" "${output}"
+  rm -f "${rc}"
+}
+
+@test "eza aliases pin every optional-value flag to an explicit value" {
+  # eza's --icons, --hyperlink, --classify and --color all take an OPTIONAL
+  # value, so a bare long form swallows the following path: `ls /tmp` becomes
+  # `--icons=/tmp` and errors to stderr with an empty stdout, which reads as a
+  # valid answer. Short forms (-F) attach their value and are unaffected.
+  # Read alias definitions only: the prose above the `ls` alias names the bare
+  # flags it warns about, and would match otherwise. Within those lines, match a
+  # flag NOT followed by '=', which catches a trailing quote or end of line as
+  # well as whitespace. Excluding '-' and alphanumerics keeps real flags like
+  # --color-scale from tripping it.
+  local bare
+  bare=$(grep -E '^[[:space:]]*alias ' "${DOTFILES}/zsh/.config/zsh/aliases.zsh" |
+    grep -E -- '--(icons|hyperlink|classify|color|colour)([^=[:alnum:]-]|$)' || true)
+
+  assert_equals "" "${bare}" "optional-value flags must be written as --flag=value"
+}

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -93,3 +93,25 @@ fi
 # tabtab source for packages
 # uninstall by removing these lines
 [[ -f ~/.config/tabtab/zsh/__tabtab.zsh ]] && . ~/.config/tabtab/zsh/__tabtab.zsh || true
+
+# Keep the alias layer away from agents.
+#
+# Aliases are the human presentation layer: pretty output, muscle memory. Coding
+# agents (Claude Code) run non-interactive shells that want the opposite — plain,
+# parse-stable output. Abbreviations already can't reach agents (expansion needs
+# ZLE), but aliases do: Claude Code snapshots the shell and replays it into every
+# tool call. Dropping them here means an agent sees /bin/ls, not eza.
+#
+# This works because that snapshot is taken from a LOGIN, NON-INTERACTIVE shell —
+# verified, not assumed: its recorded options include `login` but not `interactive`,
+# and its captured function set matches a non-interactive source exactly (74 vs the
+# 96 an interactive one yields).
+#
+# Must stay last. Aliases arrive from three places — plugins.zsh (the exa plugin
+# defines ls/ll/la/tree), aliases.zsh, and .zshrc.local — and only a sweep after
+# all of them catches every one. Guarding an individual block instead would leave
+# the plugin's own `ls` alive for agents.
+#
+# Functions and environment are untouched, so gcom/gpum/grbm, PATH, and asdf shims
+# all still work for agents.
+[[ -o interactive ]] || unalias -a

--- a/zsh/README.md
+++ b/zsh/README.md
@@ -11,6 +11,53 @@ Zsh is the primary shell, configured with [zsh-abbr](https://zsh-abbr.olets.dev)
 | `.config/zsh/plugins.zsh`            | Plugin declarations (loaded by Zap)                              |
 | `.config/zsh/*.sh`                   | Topic-specific config (docker, aliases, etc.)                    |
 
+## Agents and the Alias Layer
+
+This config serves two audiences that want opposite things. A human at a prompt wants pretty output, colour, and confirmation prompts. A coding agent (Claude Code) runs a **non-interactive** shell and wants plain, parseable, non-blocking output. Where they collide, the agent loses silently.
+
+The two layers behave completely differently:
+
+| Layer                      | Count | Reaches agents? | Why                                                        |
+| -------------------------- | ----- | --------------- | ---------------------------------------------------------- |
+| **Abbreviations** (zsh-abbr) | ~340  | **No**          | expansion needs ZLE; a non-interactive shell has no line editor |
+| **Aliases**                | 32    | **Yes**         | Claude Code snapshots the shell and replays it into every tool call |
+
+The rule that falls out:
+
+> If it is for humans — pretty output, confirmation prompts, muscle memory — make it an **abbreviation**.
+> If it must be an **alias**, it will reach agents, so it has to be non-interactive, plain, and parse-stable.
+
+The abbreviation layer is correct _by construction_. `abbr "cp"="gcp -iv"` and `abbr "mv"="mv -iv"` are the single worst class of agent hazard — a confirmation prompt with no TTY blocks forever — and they are safely quarantined purely by being abbreviations.
+
+### The Guard
+
+The last line of `.zshrc` sweeps the alias layer away from agents:
+
+```bash
+[[ -o interactive ]] || unalias -a
+```
+
+This works because Claude Code takes its snapshot from a **login, non-interactive** shell. That was verified rather than assumed: the snapshot's own recorded options include `login` but not `interactive`, and replaying Claude Code's exact capture (`typeset +f | grep -vE '^_[^_]'`) non-interactively reproduces the real snapshot's function set exactly, where an interactive shell yields extra ZLE and fzf widgets that appear nowhere in it.
+
+**Placement is load-bearing — it must stay last.** Aliases arrive from three places: `plugins.zsh` (the [exa plugin](https://github.com/zap-zsh/exa) defines `ls`, `ll`, `la`, `tree`), `aliases.zsh`, and `.zshrc.local`. Only a sweep after all three catches every one. Guarding an individual block instead would leave the plugin's own `ls` alive for agents — and on a fork whose plugin clone predates the upstream fix, it would strip the local `--icons=auto` pin while leaving the bare `--icons` alias in place, reintroducing the very bug that pin prevents.
+
+Agents keep everything they actually need. Only aliases are swept: functions (`gcom`, `gpum`, `grbm`, `gll`, `loadsecrets`), `PATH`, asdf shims, and environment variables are untouched. An agent simply sees `/bin/ls` instead of eza.
+
+### The Optional-Value Flag Trap
+
+eza's `--icons`, `--hyperlink`, `--classify`, and `--color` all take an **optional** value. Written bare before a path, each one swallows it:
+
+```bash
+eza --icons /tmp
+# error: invalid value '/tmp' for '--icons [<WHEN>]'
+```
+
+The error goes to stderr and stdout is empty — which reads as a valid answer. This is the worst failure class: a hang is obvious and gets killed, but an empty result is how wrong conclusions get made confidently. Always pin the value explicitly (`--icons=auto`). Short forms (`-F`) attach their value and are unaffected. `tests/shell_safety/` enforces this.
+
+### Not Ours to Fix
+
+Inside a Claude Code session, `find` and `grep` are shell functions that shadow the real binaries with embedded `bfs`/`ugrep`. These come from Claude Code itself, which appends them to every snapshot after capturing the user's shell — they are not defined anywhere in this repo, and no dotfiles change can alter them.
+
 ## History Cleanup
 
 zsh-autosuggestions shows "shadow text" completions sourced from `~/.zsh_history`. Erroneous commands that make it into history will keep appearing as suggestions. Here's how to remove them.


### PR DESCRIPTION
## Summary

- Sweeps the alias layer away from non-interactive agent shells with one guarded line, ending the silent-empty and format-drift classes for agents while leaving the interactive shell untouched.
- Answers #234's open guard question empirically rather than by assumption — and finds that the guard the issue proposed would have been actively harmful, so this implements a corrected form.
- Records the rule and its reasoning durably, so forks inherit *why* rather than just the fixes.

Measured: agents **32 → 0** aliases, humans unchanged at **32**, functions **74 → 74**.

## Changes

**`fix(zsh)`** — `[[ -o interactive ]] || unalias -a` as the last line of `.zshrc`.

**`test(zsh)`** — new `tests/shell_safety/`: the guard exists, stays last, drops aliases non-interactively, keeps them interactively, leaves functions intact, and no eza optional-value flag is written bare.

**`docs(zsh)`** — the rule, the evidence, and the flag trap in `zsh/README.md`; the rule plus its two day-to-day consequences in `CLAUDE.md`.

## The guard question: answered

Verified three independent ways:

- a canary in `.zshrc` reports `interactive=NO` (`$- = 4569BJXYghkl`, no `i`) when Claude Code sources it;
- the snapshot's own `# Shell Options` section records `setopt login` but **not** `setopt interactive`;
- replaying Claude Code's exact capture (`typeset +f | grep -vE '^_[^_]'`) non-interactively reproduces the real snapshot's **74** function names *exactly*; an interactive shell yields **96**, and none of those 22 extra ZLE/fzf widgets — all of which survive the filter — appear in the real snapshot.

The snapshot shell is **login, non-interactive**, so the guard works.

## Why the guard is last (load-bearing)

Wrapping the `aliases.zsh` block — the form #234 proposed — would have been worse than doing nothing. `ll`/`la`/`tree` come from the **exa plugin**, and `plugins.zsh` is not ours to guard, so the plugin's `ls` survives and agents keep eza regardless. Worse, on a fork whose plugin clone predates `be8371b`, it strips our protective `--icons=auto` pin while leaving the bare `--icons` alias alive — reintroducing #232 on exactly the forks that pin exists to protect.

Blast radius is exactly the agent snapshot: zsh reads `.zshrc` for interactive shells only, so a plain `zsh -c` never had these aliases. Only Claude Code's snapshot script sources it non-interactively. Functions (`gcom`, `gpum`, `grbm`, `gll`), `PATH`, asdf shims, and env vars are all untouched.

## Notes

- **`find`/`grep` are out of scope — they're Claude Code's.** It appends `# Shadow find/grep with embedded bfs/ugrep` to every snapshot *after* capturing the user's shell. Neither is defined in this repo and no dotfiles change can affect them, so the `find -newermt` drift in #234 is not ours to fix.
- **The optional-value class is four flags, not one.** eza's `--icons`, `--hyperlink`, `--classify`, `--color` all swallow a following path in their *long* form; short `-F` attaches its value and is safe, so `abbr "l"="ls -lhF --git"` was never affected. The test enforces the class, not the one instance.
- **Redundancy is intentional.** `tree` (plugin alias) and `t2` (abbr) expand identically, and `t2`–`t4a` depend on `ll`. That dependency is coherent *because* both layers are now human-only — abbreviations expand via ZLE at a prompt where the aliases exist.
- **Fixes don't reach a running session.** `ls` was still broken *inside the session that audited it*: snapshots are cached and replayed, so an in-flight agent keeps the old aliases until restart. Worth an `exec zsh` / new session after merge. Documented in `CLAUDE.md`.
- Full audit detail is in the [issue comment](https://github.com/joshukraine/dotfiles/issues/234#issuecomment-5001854101).

## Testing

- [x] Tests pass — 88/88 (`./scripts/run-tests`), 6 new
- [x] `./scripts/lint-shell` clean (44 scripts); `markdownlint-cli2` clean (39 files)
- [x] Manual testing done — agent shell `0` aliases with `ls` → `/bin/ls`; interactive shell `32` aliases with `ls` → eza; `ls /tmp` now returns results in a non-interactive shell (the original #231 failure)
- [x] **Mutation-tested**, since a green test proves nothing until it has been seen to fail. The first version of the flag test was vacuous — it passed with the `--icons` bug reintroduced, because the flag is followed by a quote rather than whitespace. The fixed version fails on bare `--icons` and bare `--hyperlink`, and stays green on `--color-scale` and `--color=never`; the placement test fails when the guard is no longer last.

Closes #234
Refs #231
