### PR TITLE
feat(bin): grow bubo into a staleness report for every managed surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,37 @@ The configuration includes intelligent git functions that automatically detect y
 
 These functions work with both `main` and `master` branch names automatically.
 
+## Staleness Reporting
+
+`bubo` reports what in the environment has drifted, across every surface `setup.sh` installs: Homebrew, Zap and its plugins, tmux/tpm plugins, asdf plugins and tool versions, Neovim/lazy, and Mason. It prints the command to fix anything that is behind.
+
+```bash
+bubo
+```
+
+```text
+tmux plugins (tpm)           2 stale, 2 current
+  tpm                        99469c4 -> e261deb
+  vim-tmux-navigator         c45243d -> e41c431
+  fix: ~/.config/tmux/plugins/tpm/bin/update_plugins all
+
+mason                        4 stale, 33 current
+  registry data: 4h old
+  tree-sitter-cli            v0.26.10 -> v0.26.11
+  fix: nvim +Mason  (then press U)
+```
+
+**It installs and upgrades nothing.** Index and registry refreshes are permitted and unavoidable — `brew update` refreshes the tap index, and lazy fetches — but nothing changes version. Fixing is always a separate, deliberate act. `bubc` upgrades Homebrew; the other fix commands are printed next to whatever needs them.
+
+Everything runs in parallel, because the cost is almost entirely network round trips: the clone probes alone take 4.2s sequentially against 0.6s in parallel. The full report costs about 3s, against 2.5s for the `brew update && brew outdated` that `bubo` used to be.
+
+Two properties are worth knowing, because both were learned from real bugs:
+
+- **A probe that cannot reach the network reports `UNKNOWN`, never "current".** A report that under-reports staleness is worse than no report, because it turns "I don't know" into "you're fine". Same reason a symbolic asdf pin like `stable` reports `UNKNOWN`: it resolves at runtime, so comparing it against a version number is not a comparison.
+- **Clone staleness compares HEAD SHAs**, rather than asking whether the remote HEAD object exists locally. The latter is the obvious check and it silently lies — the object is routinely already in the local store from an earlier fetch even though `HEAD` never moved. It called both `tpm` and `vim-tmux-navigator` current while each sat a commit behind.
+
+That second bug is not hypothetical: a stale Zap plugin clone kept a fixed-upstream bug alive locally for 10 months, and nothing surfaced it.
+
 ## Claude Code
 
 [Claude Code][claude-code] is Anthropic's CLI tool for AI-assisted development. This repo includes a full configuration under the `claude/` directory, stowed to `~/.claude/`.

--- a/bin/.local/bin/bubo
+++ b/bin/.local/bin/bubo
@@ -340,6 +340,16 @@ local function probe_lazy()
     return
   end
 
+  -- Load-bearing, and not obvious. lazy's Task:spawn only records a failed
+  -- process against the task when it is NOT in headless-process mode; headless
+  -- writes the output straight to stdout instead. Left alone, task:has_errors()
+  -- is therefore always false here, every failed fetch looks like a clean one,
+  -- and an offline run reports every plugin as current off the remote-tracking
+  -- refs left behind by the last successful fetch. Verified: with this line, an
+  -- offline check reports 57 of 57 plugins errored; without it, 0.
+  local config = require("lazy.core.config")
+  config.options.headless.process = false
+
   -- wait = true makes lazy's async check synchronous; show = false keeps the UI
   -- closed. This fetches, which is an index refresh, and installs nothing.
   if not pcall(function()
@@ -349,7 +359,7 @@ local function probe_lazy()
     return
   end
 
-  for name, plugin in pairs(require("lazy.core.config").plugins) do
+  for name, plugin in pairs(config.plugins) do
     local state = plugin._ or {}
 
     -- Mirrors the set lazy.check itself operates on.

--- a/bin/.local/bin/bubo
+++ b/bin/.local/bin/bubo
@@ -108,15 +108,23 @@ render_records() {
 
 # --- git clones --------------------------------------------------------------
 
-# Classify one git clone against its origin's HEAD.
+# Classify one git clone against the branch it tracks.
 # Prints a tab-separated "<name> <status> <detail>" record.
 #
 # Compares HEAD SHAs rather than asking whether the remote SHA is present
 # locally: the object is routinely already in the local store from an earlier
 # fetch even though HEAD never moved, which reports stale clones as current.
+#
+# The remote SHA comes from the branch this clone actually tracks, not from the
+# remote's default branch. zap ships checked out on release-v1 while its origin
+# HEAD points at master, so `ls-remote origin HEAD` compares two unrelated
+# branches and reports zap permanently stale -- a false positive no `zap update`
+# can clear, because zap is in fact current on release-v1. A clone with no
+# upstream (detached HEAD, or no tracking configured) falls back to the remote's
+# default branch, the best answer available.
 probe_clone() {
   local dir="$1"
-  local name local_sha="" remote_sha=""
+  local name local_sha="" remote_sha="" upstream remote_ref
 
   name="$(basename "${dir}")"
 
@@ -126,7 +134,16 @@ probe_clone() {
     return 0
   fi
 
-  remote_sha="$(git -C "${dir}" ls-remote origin HEAD 2>/dev/null | awk 'NR == 1 { print $1 }')" || remote_sha=""
+  # `@{upstream}` abbreviates to "<remote>/<branch>"; strip the remote to get
+  # the branch. Remote names carry no slash, so #*/ leaves branch names that do.
+  upstream="$(git -C "${dir}" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null)" || upstream=""
+  if [[ -n "${upstream}" ]]; then
+    remote_ref="refs/heads/${upstream#*/}"
+  else
+    remote_ref="HEAD"
+  fi
+
+  remote_sha="$(git -C "${dir}" ls-remote origin "${remote_ref}" 2>/dev/null | awk 'NR == 1 { print $1 }')" || remote_sha=""
   if [[ -z "${remote_sha}" ]]; then
     printf '%s\tUNKNOWN\tno answer from origin\n' "${name}"
     return 0

--- a/bin/.local/bin/bubo
+++ b/bin/.local/bin/bubo
@@ -1,8 +1,515 @@
 #!/usr/bin/env bash
 #
-# Update Homebrew and show outdated packages
+# Report which dotfiles-managed tools have gone stale
 # Usage: bubo
+#
+# Probes every surface setup.sh installs -- homebrew, zap, tpm, asdf, lazy, mason
+# -- and prints the command to fix anything that is behind.
+#
+# Installs and upgrades nothing. Index and registry refreshes are permitted and
+# unavoidable (brew update refreshes the tap index; lazy fetches), but no
+# installed software changes version.
+#
+# Probes run in parallel because the cost is almost entirely network round trips:
+# the clone probes alone take 4.2s sequentially against 0.6s in parallel.
+#
+# Two rules this report is built around, both learned from real bugs:
+#
+#   1. A probe that cannot reach the network reports UNKNOWN, never "current".
+#      A report that under-reports staleness is worse than no report, because it
+#      turns "I don't know" into "you're fine".
+#
+#   2. Clone staleness compares HEAD SHAs. The obvious check -- does the remote
+#      HEAD object exist locally, via `git cat-file -e` -- finds objects pulled
+#      in by an earlier fetch and calls stale clones current.
+#
+# See https://github.com/joshukraine/dotfiles/issues/236.
 
 set -euo pipefail
 
-brew update && brew outdated
+ZAP_DIR="${ZAP_DIR:-${XDG_DATA_HOME:-${HOME}/.local/share}/zap}"
+TMUX_PLUGIN_DIR="${XDG_CONFIG_HOME:-${HOME}/.config}/tmux/plugins"
+ASDF_DATA_DIR="${ASDF_DATA_DIR:-${HOME}/.asdf}"
+TOOL_VERSIONS="${HOME}/.tool-versions"
+
+# Bound the network probes. Git has no timeout flag, but it will abort a transfer
+# that stalls, which keeps a black-holed connection from hanging the report.
+export GIT_TERMINAL_PROMPT=0
+export GIT_HTTP_LOW_SPEED_LIMIT=1000
+export GIT_HTTP_LOW_SPEED_TIME=10
+
+# --- output ------------------------------------------------------------------
+
+section() {
+  printf '%-28s %s\n' "$1" "$2"
+}
+
+item() {
+  printf '  %-26s %s\n' "$1" "$2"
+}
+
+note() {
+  printf '  %s\n' "$1"
+}
+
+fix() {
+  printf '  fix: %s\n' "$1"
+}
+
+# Join non-zero counts into a verdict like "2 stale, 1 unknown, 12 current".
+# Args: <count> <label> [<count> <label> ...]
+summary() {
+  local out=""
+
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" -gt 0 ]]; then
+      [[ -z "${out}" ]] || out="${out}, "
+      out="${out}$1 $2"
+    fi
+    shift 2
+  done
+
+  printf '%s' "${out}"
+}
+
+# Render a section from tab-separated "<name> <status> <detail>" records on stdin.
+# Only non-current items are listed; the rest are counted in the verdict.
+# Args: <label> <fix command> [<note>]
+render_records() {
+  local label="$1" fix_cmd="$2" note_line="${3:-}"
+  local name status detail
+  local stale=0 ahead=0 unknown=0 current=0 lines=""
+
+  while IFS=$'\t' read -r name status detail; do
+    case "${status}" in
+      CURRENT)
+        current=$((current + 1))
+        ;;
+      STALE)
+        stale=$((stale + 1))
+        lines="${lines}$(item "${name}" "${detail}")"$'\n'
+        ;;
+      AHEAD)
+        ahead=$((ahead + 1))
+        lines="${lines}$(item "${name}" "${detail}")"$'\n'
+        ;;
+      UNKNOWN)
+        unknown=$((unknown + 1))
+        lines="${lines}$(item "${name}" "UNKNOWN: ${detail}")"$'\n'
+        ;;
+    esac
+  done
+
+  section "${label}" "$(summary "${stale}" stale "${ahead}" ahead "${unknown}" unknown "${current}" current)"
+  [[ -z "${note_line}" ]] || note "${note_line}"
+  [[ -z "${lines}" ]] || printf '%s' "${lines}"
+  [[ "${stale}" -eq 0 ]] || fix "${fix_cmd}"
+}
+
+# --- git clones --------------------------------------------------------------
+
+# Classify one git clone against its origin's HEAD.
+# Prints a tab-separated "<name> <status> <detail>" record.
+#
+# Compares HEAD SHAs rather than asking whether the remote SHA is present
+# locally: the object is routinely already in the local store from an earlier
+# fetch even though HEAD never moved, which reports stale clones as current.
+probe_clone() {
+  local dir="$1"
+  local name local_sha="" remote_sha=""
+
+  name="$(basename "${dir}")"
+
+  local_sha="$(git -C "${dir}" rev-parse HEAD 2>/dev/null)" || local_sha=""
+  if [[ -z "${local_sha}" ]]; then
+    printf '%s\tUNKNOWN\tnot a git clone\n' "${name}"
+    return 0
+  fi
+
+  remote_sha="$(git -C "${dir}" ls-remote origin HEAD 2>/dev/null | awk 'NR == 1 { print $1 }')" || remote_sha=""
+  if [[ -z "${remote_sha}" ]]; then
+    printf '%s\tUNKNOWN\tno answer from origin\n' "${name}"
+    return 0
+  fi
+
+  if [[ "${local_sha}" == "${remote_sha}" ]]; then
+    printf '%s\tCURRENT\t\n' "${name}"
+  elif git -C "${dir}" merge-base --is-ancestor "${remote_sha}" "${local_sha}" 2>/dev/null; then
+    printf '%s\tAHEAD\tlocal commits on top of %s\n' "${name}" "${remote_sha:0:7}"
+  else
+    printf '%s\tSTALE\t%s -> %s\n' "${name}" "${local_sha:0:7}" "${remote_sha:0:7}"
+  fi
+}
+
+# List every immediate subdirectory of a parent that is a git clone.
+clone_dirs_in() {
+  local parent="$1" dir
+
+  [[ -d "${parent}" ]] || return 0
+
+  for dir in "${parent}"/*/; do
+    [[ -e "${dir}.git" ]] || continue
+    printf '%s\n' "${dir%/}"
+  done
+}
+
+# Probe a set of clones in parallel and render them as one section.
+# Args: <label> <fix command> [<clone dir> ...]
+report_clone_group() {
+  local label="$1" fix_cmd="$2"
+  shift 2
+
+  if [[ "$#" -eq 0 ]]; then
+    section "${label}" "skipped: no clones found"
+    return 0
+  fi
+
+  local tmpdir dir
+  tmpdir="$(mktemp -d)"
+
+  for dir in "$@"; do
+    probe_clone "${dir}" >"${tmpdir}/$(basename "${dir}")" &
+  done
+  wait
+
+  render_records "${label}" "${fix_cmd}" < <(cat "${tmpdir}"/* | sort)
+  rm -rf "${tmpdir}"
+}
+
+# --- probes ------------------------------------------------------------------
+
+probe_brew() {
+  local label="homebrew"
+  local outdated="" count
+
+  if ! command -v brew >/dev/null 2>&1; then
+    section "${label}" "skipped: brew not installed"
+    return 0
+  fi
+
+  # The tap-index refresh bubo has always done, and the reason `brew outdated`
+  # can answer honestly.
+  if ! brew update >/dev/null 2>&1; then
+    section "${label}" "UNKNOWN: brew update failed"
+    return 0
+  fi
+
+  if ! outdated="$(brew outdated 2>/dev/null)"; then
+    section "${label}" "UNKNOWN: brew outdated failed"
+    return 0
+  fi
+
+  if [[ -z "${outdated}" ]]; then
+    section "${label}" "current"
+    return 0
+  fi
+
+  count="$(printf '%s\n' "${outdated}" | wc -l | tr -d ' ')"
+  section "${label}" "${count} stale"
+  printf '%s\n' "${outdated}" | sed 's/^/  /'
+  fix "bubc"
+}
+
+probe_zap() {
+  local label="zsh plugins (zap)"
+  local dirs=() dir
+
+  if [[ ! -d "${ZAP_DIR}" ]]; then
+    section "${label}" "skipped: zap not installed"
+    return 0
+  fi
+
+  # Zap itself is a clone, and goes stale exactly like the plugins it manages.
+  if [[ -e "${ZAP_DIR}/.git" ]]; then
+    dirs+=("${ZAP_DIR}")
+  fi
+
+  while IFS= read -r dir; do
+    dirs+=("${dir}")
+  done < <(clone_dirs_in "${ZAP_DIR}/plugins")
+
+  report_clone_group "${label}" 'zap update all' ${dirs[@]+"${dirs[@]}"}
+}
+
+probe_tmux() {
+  local label="tmux plugins (tpm)"
+  local dirs=() dir
+
+  while IFS= read -r dir; do
+    dirs+=("${dir}")
+  done < <(clone_dirs_in "${TMUX_PLUGIN_DIR}")
+
+  report_clone_group "${label}" "${TMUX_PLUGIN_DIR}/tpm/bin/update_plugins all" ${dirs[@]+"${dirs[@]}"}
+}
+
+probe_asdf_plugins() {
+  local label="asdf plugins"
+  local dirs=() dir
+
+  while IFS= read -r dir; do
+    dirs+=("${dir}")
+  done < <(clone_dirs_in "${ASDF_DATA_DIR}/plugins")
+
+  report_clone_group "${label}" 'asdf plugin update --all' ${dirs[@]+"${dirs[@]}"}
+}
+
+# Compare one pin from .tool-versions against the newest version asdf knows of.
+# Prints a tab-separated "<tool> <status> <detail>" record.
+#
+# asdf latest only knows what the plugin's vendored version definitions know, so
+# a stale asdf plugin makes this under-report. That is what the asdf plugin probe
+# above is for: the plugin axis is what keeps this one honest.
+probe_asdf_tool() {
+  local tool="$1" pinned="$2"
+  local latest="" version
+  local pins=()
+
+  read -ra pins <<<"${pinned}"
+
+  for version in ${pins[@]+"${pins[@]}"}; do
+    # Symbolic pins ("stable", "lts", "system", "ref:...") resolve at runtime.
+    # String-comparing one against a version number is not a comparison at all,
+    # and would report a permanent false "stale".
+    if [[ "${version}" != [0-9]* ]]; then
+      printf '%s\tUNKNOWN\t"%s" is symbolic, not comparable\n' "${tool}" "${version}"
+      return 0
+    fi
+  done
+
+  latest="$(asdf latest "${tool}" 2>/dev/null)" || latest=""
+  if [[ -z "${latest}" ]]; then
+    printf '%s\tUNKNOWN\tasdf latest gave no answer\n' "${tool}"
+    return 0
+  fi
+
+  for version in ${pins[@]+"${pins[@]}"}; do
+    if [[ "${version}" == "${latest}" ]]; then
+      printf '%s\tCURRENT\t\n' "${tool}"
+      return 0
+    fi
+  done
+
+  printf '%s\tSTALE\t%s -> %s\n' "${tool}" "${pinned}" "${latest}"
+}
+
+probe_asdf_versions() {
+  local label="asdf tool versions"
+  local tmpdir tool versions
+
+  if ! command -v asdf >/dev/null 2>&1; then
+    section "${label}" "skipped: asdf not installed"
+    return 0
+  fi
+
+  if [[ ! -f "${TOOL_VERSIONS}" ]]; then
+    section "${label}" "skipped: ${TOOL_VERSIONS} not present"
+    return 0
+  fi
+
+  tmpdir="$(mktemp -d)"
+
+  while read -r tool versions; do
+    case "${tool}" in
+      '' | \#*) continue ;;
+    esac
+    probe_asdf_tool "${tool}" "${versions}" >"${tmpdir}/${tool}" &
+  done <"${TOOL_VERSIONS}"
+  wait
+
+  render_records "${label}" "asdf install <tool> <version>, then update ${TOOL_VERSIONS}" \
+    < <(cat "${tmpdir}"/* | sort)
+  rm -rf "${tmpdir}"
+}
+
+# --- neovim ------------------------------------------------------------------
+
+# lazy and mason are both Lua APIs inside the same editor, so one headless nvim
+# answers for both surfaces and the startup cost is paid once.
+nvim_probe_lua() {
+  cat <<'LUA'
+-- Records are sentinel-prefixed and tab-separated so that unrelated nvim output
+-- cannot be mistaken for a probe result.
+local function emit(...)
+  io.stdout:write(table.concat({ "BUBO", ... }, "\t") .. "\n")
+end
+
+local function probe_lazy()
+  local ok, lazy = pcall(require, "lazy")
+  if not ok then
+    emit("LAZY_ABSENT")
+    return
+  end
+
+  -- wait = true makes lazy's async check synchronous; show = false keeps the UI
+  -- closed. This fetches, which is an index refresh, and installs nothing.
+  if not pcall(function()
+    lazy.check({ show = false, wait = true })
+  end) then
+    emit("LAZY_FAILED")
+    return
+  end
+
+  for name, plugin in pairs(require("lazy.core.config").plugins) do
+    local state = plugin._ or {}
+
+    -- Mirrors the set lazy.check itself operates on.
+    if plugin.url and state.installed then
+      local failed = false
+      for _, task in ipairs(state.tasks or {}) do
+        if task.has_errors and task:has_errors() then
+          failed = true
+        end
+      end
+
+      if failed then
+        -- A plugin whose fetch failed has no verdict, and must not read as current.
+        emit("LAZY", name, "UNKNOWN", "fetch failed")
+      elseif state.updates then
+        local from = string.sub((state.updates.from or {}).commit or "", 1, 7)
+        local to = string.sub((state.updates.to or {}).commit or "", 1, 7)
+        emit("LAZY", name, "STALE", from .. " -> " .. to)
+      else
+        emit("LAZY", name, "CURRENT", "")
+      end
+    end
+  end
+end
+
+-- The mason probe reads the cached registry, so it is only as honest as that
+-- cache is fresh. Without reporting the cache's age, a stale registry silently
+-- reports outdated packages as current.
+local function registry_age()
+  local newest = nil
+
+  for _, file in ipairs(vim.fn.glob(vim.fn.stdpath("data") .. "/mason/registries/*/*/*/info.json", false, true)) do
+    local ok, data = pcall(function()
+      return vim.json.decode(table.concat(vim.fn.readfile(file), "\n"))
+    end)
+    if ok and type(data) == "table" and data.download_timestamp then
+      if not newest or data.download_timestamp > newest then
+        newest = data.download_timestamp
+      end
+    end
+  end
+
+  if not newest then
+    return "age unknown"
+  end
+
+  local age = os.time() - newest
+  if age < 3600 then
+    return string.format("%dm old", math.floor(age / 60))
+  elseif age < 86400 then
+    return string.format("%dh old", math.floor(age / 3600))
+  end
+  return string.format("%dd old", math.floor(age / 86400))
+end
+
+local function probe_mason()
+  local ok, registry = pcall(require, "mason-registry")
+  if not ok then
+    emit("MASON_ABSENT")
+    return
+  end
+
+  for _, pkg in ipairs(registry.get_installed_packages()) do
+    local installed_ok, installed = pcall(pkg.get_installed_version, pkg)
+    local latest_ok, latest = pcall(pkg.get_latest_version, pkg)
+
+    if not (installed_ok and latest_ok) then
+      emit("MASON", pkg.name, "UNKNOWN", "registry has no version for it")
+    elseif installed == latest then
+      emit("MASON", pkg.name, "CURRENT", "")
+    else
+      emit("MASON", pkg.name, "STALE", installed .. " -> " .. latest)
+    end
+  end
+
+  emit("MASON_AGE", registry_age())
+end
+
+pcall(probe_lazy)
+pcall(probe_mason)
+io.stdout:flush()
+vim.cmd("qa!")
+LUA
+}
+
+# True when the nvim probe emitted a bare marker such as LAZY_ABSENT.
+nvim_probe_marker() {
+  printf '%s\n' "$1" | awk -F'\t' -v marker="$2" '$2 == marker { found = 1 } END { exit !found }'
+}
+
+# Extract the "<name> <status> <detail>" records for one surface.
+nvim_probe_records() {
+  printf '%s\n' "$1" | awk -F'\t' -v kind="$2" '$2 == kind { print $3 "\t" $4 "\t" $5 }' | sort
+}
+
+probe_nvim() {
+  local lazy_label="nvim plugins (lazy)" mason_label="mason"
+  local luafile raw="" age=""
+
+  if ! command -v nvim >/dev/null 2>&1; then
+    section "${lazy_label}" "skipped: nvim not installed"
+    printf '\n'
+    section "${mason_label}" "skipped: nvim not installed"
+    return 0
+  fi
+
+  luafile="$(mktemp)"
+  nvim_probe_lua >"${luafile}"
+  raw="$(nvim --headless -c "luafile ${luafile}" 2>/dev/null | grep '^BUBO' || true)"
+  rm -f "${luafile}"
+
+  if nvim_probe_marker "${raw}" LAZY_ABSENT; then
+    section "${lazy_label}" "skipped: lazy.nvim not loaded"
+  elif nvim_probe_marker "${raw}" LAZY_FAILED; then
+    section "${lazy_label}" "UNKNOWN: lazy check did not complete"
+  else
+    render_records "${lazy_label}" 'nvim "+Lazy sync"' < <(nvim_probe_records "${raw}" LAZY)
+  fi
+
+  printf '\n'
+
+  if nvim_probe_marker "${raw}" MASON_ABSENT; then
+    section "${mason_label}" "skipped: mason.nvim not loaded"
+    return 0
+  fi
+
+  age="$(printf '%s\n' "${raw}" | awk -F'\t' '$2 == "MASON_AGE" { print $3; exit }')"
+  render_records "${mason_label}" 'nvim +Mason  (then press U)' "registry data: ${age:-age unknown}" \
+    < <(nvim_probe_records "${raw}" MASON)
+}
+
+# --- report ------------------------------------------------------------------
+
+main() {
+  local file first=1
+
+  # Deliberately global: the EXIT trap fires after main has returned, by which
+  # point a local would be out of scope and unset.
+  BUBO_TMPDIR="$(mktemp -d)"
+  trap 'rm -rf "${BUBO_TMPDIR}"' EXIT
+
+  # Numbered so the report reads in a fixed order regardless of which probe
+  # finishes first.
+  probe_brew >"${BUBO_TMPDIR}/10-brew" &
+  probe_zap >"${BUBO_TMPDIR}/20-zap" &
+  probe_tmux >"${BUBO_TMPDIR}/30-tmux" &
+  probe_asdf_plugins >"${BUBO_TMPDIR}/40-asdf-plugins" &
+  probe_asdf_versions >"${BUBO_TMPDIR}/50-asdf-versions" &
+  probe_nvim >"${BUBO_TMPDIR}/60-nvim" &
+  wait
+
+  for file in "${BUBO_TMPDIR}"/*; do
+    [[ -s "${file}" ]] || continue
+    [[ "${first}" -eq 1 ]] || printf '\n'
+    first=0
+    cat "${file}"
+  done
+}
+
+# Sourced by the test suite, which exercises the probes directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -108,7 +108,6 @@
     ],
     "defaultMode": "auto"
   },
-  "model": "claude-fable-5[1m]",
   "enableAllProjectMcpServers": false,
   "hooks": {
     "PreToolUse": [
@@ -178,7 +177,8 @@
     "enabled": false
   },
   "alwaysThinkingEnabled": true,
-  "effortLevel": "high",
+  "model": "opus[1m]",
+  "effortLevel": "xhigh",
   "tui": "fullscreen",
   "voice": {
     "enabled": true

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -3,7 +3,7 @@
 # Run dotfiles test suite using bats-core
 #
 # Usage: run-tests [category]
-#   category: all (default), git, abbr, presets
+#   category: all (default), git, abbr, presets, bubo
 
 set -e
 
@@ -40,9 +40,13 @@ case "${category}" in
     echo "Running merge-presets tests..."
     bats tests/merge_presets/
     ;;
+  bubo)
+    echo "Running bubo staleness-report tests..."
+    bats tests/bubo/
+    ;;
   *)
     echo "Unknown category: ${category}" >&2
-    echo "Available: all, git, abbr, presets" >&2
+    echo "Available: all, git, abbr, presets, bubo" >&2
     exit 1
     ;;
 esac

--- a/tests/bubo/test_bubo.bats
+++ b/tests/bubo/test_bubo.bats
@@ -1,0 +1,266 @@
+#!/usr/bin/env bats
+
+# Tests for bubo, the staleness report (see https://github.com/joshukraine/dotfiles/issues/236).
+#
+# These test the probes' classification logic, not the surfaces themselves. CI
+# has no zap, no tpm and no mason, and even locally a test that asserted "tpm is
+# one commit behind" would break the moment tpm was updated. So the clone probe
+# runs against purpose-built local fixture repos, which also keeps the suite
+# offline: a file:// origin needs no network.
+#
+# The load-bearing test here is the cat-file one. The whole report is worthless
+# if it under-reports staleness, and the obvious clone check does exactly that.
+#
+# bubo is sourced in a subshell rather than by bats directly, because it sets
+# -euo pipefail for its own use and that should not leak into the test runner.
+
+load '../helpers/common.bash'
+load '../helpers/shell_helpers.bash'
+
+setup() {
+  require_command git
+
+  BUBO="${DOTFILES}/bin/.local/bin/bubo"
+  require_file "${BUBO}"
+
+  TEST_TMPDIR="$(mktemp -d)"
+}
+
+teardown() {
+  if [ -n "${TEST_TMPDIR}" ] && [ -d "${TEST_TMPDIR}" ]; then
+    rm -rf "${TEST_TMPDIR}"
+  fi
+}
+
+# Run one of bubo's functions in a subshell and capture its output.
+run_bubo() {
+  run bash -c "source '${BUBO}' && $*"
+}
+
+# Create an origin repo and a clone of it. Sets ORIGIN and CLONE.
+#
+# init.defaultBranch is set rather than passing -b so this works on git versions
+# predating the flag; nothing here depends on the branch's name, only on HEAD.
+make_clone() {
+  ORIGIN="${TEST_TMPDIR}/origin"
+  CLONE="${TEST_TMPDIR}/clone"
+
+  git -c init.defaultBranch=main init -q "${ORIGIN}"
+  git -C "${ORIGIN}" config user.name "Test User"
+  git -C "${ORIGIN}" config user.email "test@example.com"
+  echo "one" >"${ORIGIN}/file"
+  git -C "${ORIGIN}" add file
+  git -C "${ORIGIN}" commit -qm "one"
+
+  git clone -q "${ORIGIN}" "${CLONE}"
+  git -C "${CLONE}" config user.name "Test User"
+  git -C "${CLONE}" config user.email "test@example.com"
+}
+
+# Commit to the origin, leaving the clone a commit behind.
+advance_origin() {
+  echo "two" >>"${ORIGIN}/file"
+  git -C "${ORIGIN}" add file
+  git -C "${ORIGIN}" commit -qm "two"
+}
+
+# Commit to the clone, putting it a commit ahead of the origin.
+advance_clone() {
+  echo "local" >>"${CLONE}/file"
+  git -C "${CLONE}" add file
+  git -C "${CLONE}" commit -qm "local work"
+}
+
+# Put a fake asdf on PATH whose `latest` reports a fixed version.
+mock_asdf_latest() {
+  local latest="$1"
+
+  mkdir -p "${TEST_TMPDIR}/bin"
+  cat >"${TEST_TMPDIR}/bin/asdf" <<EOF
+#!/usr/bin/env bash
+[ "\$1" = "latest" ] || exit 1
+echo "${latest}"
+EOF
+  chmod +x "${TEST_TMPDIR}/bin/asdf"
+  PATH="${TEST_TMPDIR}/bin:${PATH}"
+}
+
+# --- the test seam -----------------------------------------------------------
+
+@test "sourcing bubo does not run the report" {
+  run_bubo "echo SOURCED"
+
+  assert_equals "0" "${status}" "sourcing bubo should succeed"
+  assert_contains "${output}" "SOURCED"
+  assert_not_contains "${output}" "homebrew" "sourcing should not produce a report"
+}
+
+# --- clone staleness ---------------------------------------------------------
+
+@test "probe_clone reports a clone at origin's HEAD as current" {
+  make_clone
+
+  run_bubo "probe_clone '${CLONE}'"
+
+  assert_contains "${output}" "CURRENT"
+}
+
+@test "probe_clone reports a behind clone as stale, with both short SHAs" {
+  make_clone
+  advance_origin
+
+  local local_sha remote_sha
+  local_sha="$(git -C "${CLONE}" rev-parse --short=7 HEAD)"
+  remote_sha="$(git -C "${ORIGIN}" rev-parse --short=7 HEAD)"
+
+  run_bubo "probe_clone '${CLONE}'"
+
+  assert_contains "${output}" "STALE"
+  assert_contains "${output}" "${local_sha} -> ${remote_sha}"
+}
+
+# The one that matters. Checking "is the remote HEAD present locally?" with
+# `git cat-file -e` reports stale clones as current, because an earlier fetch
+# already pulled the object into the local store even though HEAD never moved.
+# Measured against the real tpm and vim-tmux-navigator clones, which it called
+# current while each sat a commit behind.
+#
+# The first assertion proves the fixture actually reproduces the trap, so this
+# cannot quietly stop testing anything if the setup changes.
+@test "probe_clone reports a fetched-but-unmerged clone as stale, not current" {
+  make_clone
+  advance_origin
+  git -C "${CLONE}" fetch -q origin
+
+  local remote_sha
+  remote_sha="$(git -C "${ORIGIN}" rev-parse HEAD)"
+
+  run git -C "${CLONE}" cat-file -e "${remote_sha}"
+  assert_equals "0" "${status}" "fixture is broken: the remote object should be in the local store"
+
+  run_bubo "probe_clone '${CLONE}'"
+
+  assert_contains "${output}" "STALE"
+  assert_not_contains "${output}" "CURRENT"
+}
+
+@test "probe_clone reports a clone with local commits as ahead, not stale" {
+  make_clone
+  advance_clone
+
+  run_bubo "probe_clone '${CLONE}'"
+
+  assert_contains "${output}" "AHEAD"
+  assert_not_contains "${output}" "STALE"
+}
+
+@test "probe_clone reports UNKNOWN, never current, when origin cannot be reached" {
+  make_clone
+  git -C "${CLONE}" remote set-url origin "${TEST_TMPDIR}/no-such-origin"
+
+  run_bubo "probe_clone '${CLONE}'"
+
+  assert_contains "${output}" "UNKNOWN"
+  assert_not_contains "${output}" "CURRENT"
+}
+
+@test "probe_clone reports UNKNOWN for a directory that is not a git clone" {
+  mkdir -p "${TEST_TMPDIR}/plain"
+
+  run_bubo "probe_clone '${TEST_TMPDIR}/plain'"
+
+  assert_contains "${output}" "UNKNOWN"
+  assert_not_contains "${output}" "CURRENT"
+}
+
+@test "clone_dirs_in finds clones and ignores plain directories" {
+  make_clone
+  mkdir -p "${TEST_TMPDIR}/plain"
+
+  run_bubo "clone_dirs_in '${TEST_TMPDIR}'"
+
+  assert_contains "${output}" "${CLONE}"
+  assert_not_contains "${output}" "${TEST_TMPDIR}/plain"
+}
+
+# --- asdf tool versions ------------------------------------------------------
+
+@test "probe_asdf_tool reports a pin matching latest as current" {
+  mock_asdf_latest "4.0.6"
+
+  run_bubo "PATH='${PATH}'; probe_asdf_tool ruby '4.0.6'"
+
+  assert_contains "${output}" "CURRENT"
+}
+
+@test "probe_asdf_tool reports a pin behind latest as stale" {
+  mock_asdf_latest "26.5.0"
+
+  run_bubo "PATH='${PATH}'; probe_asdf_tool nodejs '24.16.0'"
+
+  assert_contains "${output}" "STALE"
+  assert_contains "${output}" "24.16.0 -> 26.5.0"
+}
+
+@test "probe_asdf_tool reports a multi-version pin as current when one matches latest" {
+  mock_asdf_latest "3.12.4"
+
+  run_bubo "PATH='${PATH}'; probe_asdf_tool python '3.12.4 2.7.18'"
+
+  assert_contains "${output}" "CURRENT"
+}
+
+# A symbolic pin resolves at runtime, so comparing it against a version number is
+# not a comparison at all -- it would report a permanent false "stale".
+@test "probe_asdf_tool reports a symbolic pin as UNKNOWN, not stale" {
+  mock_asdf_latest "0.12.4"
+
+  run_bubo "PATH='${PATH}'; probe_asdf_tool neovim 'stable'"
+
+  assert_contains "${output}" "UNKNOWN"
+  assert_not_contains "${output}" "STALE"
+}
+
+@test "probe_asdf_tool reports UNKNOWN, never current, when asdf gives no answer" {
+  mkdir -p "${TEST_TMPDIR}/bin"
+  printf '#!/usr/bin/env bash\nexit 1\n' >"${TEST_TMPDIR}/bin/asdf"
+  chmod +x "${TEST_TMPDIR}/bin/asdf"
+
+  run_bubo "PATH='${TEST_TMPDIR}/bin:${PATH}'; probe_asdf_tool ruby '4.0.6'"
+
+  assert_contains "${output}" "UNKNOWN"
+  assert_not_contains "${output}" "CURRENT"
+}
+
+# --- rendering ---------------------------------------------------------------
+
+@test "render_records lists what is stale, counts what is current, and prints the fix" {
+  run_bubo "printf 'alpha\tCURRENT\t\nbravo\tSTALE\tabc1234 -> def5678\n' | render_records 'demo' 'run the fix'"
+
+  assert_contains "${output}" "1 stale, 1 current"
+  assert_contains "${output}" "bravo"
+  assert_contains "${output}" "abc1234 -> def5678"
+  assert_contains "${output}" "fix: run the fix"
+  assert_not_contains "${output}" "alpha" "current items should be counted, not listed"
+}
+
+@test "render_records prints no fix when nothing is stale" {
+  run_bubo "printf 'alpha\tCURRENT\t\n' | render_records 'demo' 'run the fix'"
+
+  assert_contains "${output}" "1 current"
+  assert_not_contains "${output}" "fix:"
+}
+
+@test "render_records surfaces UNKNOWN items rather than folding them into current" {
+  run_bubo "printf 'alpha\tUNKNOWN\tno answer from origin\n' | render_records 'demo' 'run the fix'"
+
+  assert_contains "${output}" "1 unknown"
+  assert_contains "${output}" "UNKNOWN: no answer from origin"
+  assert_not_contains "${output}" "current"
+}
+
+@test "render_records prints a note under the verdict when given one" {
+  run_bubo "printf 'alpha\tCURRENT\t\n' | render_records 'mason' 'run the fix' 'registry data: 4h old'"
+
+  assert_contains "${output}" "registry data: 4h old"
+}

--- a/tests/bubo/test_bubo.bats
+++ b/tests/bubo/test_bubo.bats
@@ -71,6 +71,32 @@ advance_clone() {
   git -C "${CLONE}" commit -qm "local work"
 }
 
+# Build zap's shape: an origin whose default branch has moved ahead of a side
+# branch, with the clone checked out on that side branch. origin HEAD then points
+# somewhere the clone deliberately does not track. Sets ORIGIN and CLONE.
+make_clone_on_side_branch() {
+  ORIGIN="${TEST_TMPDIR}/origin"
+  CLONE="${TEST_TMPDIR}/clone"
+
+  git -c init.defaultBranch=main init -q "${ORIGIN}"
+  git -C "${ORIGIN}" config user.name "Test User"
+  git -C "${ORIGIN}" config user.email "test@example.com"
+  echo "one" >"${ORIGIN}/file"
+  git -C "${ORIGIN}" add file
+  git -C "${ORIGIN}" commit -qm "one"
+
+  # A side branch that stays put while the default branch, where origin HEAD
+  # points, moves ahead of it -- mirroring zap's release-v1 trailing master.
+  git -C "${ORIGIN}" branch release-v1
+  echo "two" >>"${ORIGIN}/file"
+  git -C "${ORIGIN}" add file
+  git -C "${ORIGIN}" commit -qm "two"
+
+  git clone -q --branch release-v1 "${ORIGIN}" "${CLONE}"
+  git -C "${CLONE}" config user.name "Test User"
+  git -C "${CLONE}" config user.email "test@example.com"
+}
+
 # Put a fake asdf on PATH whose `latest` reports a fixed version.
 mock_asdf_latest() {
   local latest="$1"
@@ -142,6 +168,29 @@ EOF
 
   assert_contains "${output}" "STALE"
   assert_not_contains "${output}" "CURRENT"
+}
+
+# The zap trap. A clone deliberately checked out on a non-default branch tracks
+# a branch the remote HEAD symref never points to. Comparing local HEAD against
+# `ls-remote origin HEAD` then pits the tracked branch against the remote default
+# and reports a current clone permanently stale -- exactly what bubo did to zap,
+# which ships on release-v1 while its origin HEAD points at a further-ahead
+# master. The comparison must be against the branch the clone tracks.
+#
+# The first assertion proves the fixture reproduces the trap, so this cannot
+# quietly stop testing anything if the setup changes.
+@test "probe_clone reports a clone tracking a non-default branch as current" {
+  make_clone_on_side_branch
+
+  local head_sha default_sha
+  head_sha="$(git -C "${CLONE}" rev-parse HEAD)"
+  default_sha="$(git -C "${CLONE}" ls-remote origin HEAD | awk 'NR == 1 { print $1 }')"
+  assert_not_equals "${head_sha}" "${default_sha}" "fixture is broken: origin HEAD should differ from the tracked branch"
+
+  run_bubo "probe_clone '${CLONE}'"
+
+  assert_contains "${output}" "CURRENT"
+  assert_not_contains "${output}" "STALE"
 }
 
 @test "probe_clone reports a clone with local commits as ahead, not stale" {


### PR DESCRIPTION
## Summary

- Grows `bubo` from a brew-only wrapper into a single read-only staleness report for every dotfiles-managed surface — homebrew, zap, tpm, asdf (plugins + tool versions), nvim/lazy, and mason.
- Reports only: prints what's stale and the exact command to fix it, installs and upgrades nothing. Index/registry refreshes (`brew update`, `lazy` fetch) are permitted; no installed software changes version.
- Designed against one failure mode above all — a probe that can't answer reports **UNKNOWN, never "current"** — because a report that under-reports staleness is worse than no report.

## Changes

### Features
- `feat(bin)`: one git-clone probe covers 14 surfaces (zap, tpm, and asdf plugin clones); dedicated probes for brew, asdf tool versions, and a single headless nvim answering for both lazy and mason. Probes run in parallel (the cost is almost entirely network round trips).

### Fixes
- `fix(bubo)`: the lazy probe no longer reports every plugin current when offline — it forces `headless.process = false` so failed fetches are recorded against the task instead of being written straight to stdout and lost.
- `fix(bubo)`: clone staleness now compares against the branch each clone actually tracks (`@{upstream}`), not the remote's default branch. zap ships checked out on `release-v1` while its origin HEAD points at a further-ahead `master`, which made `ls-remote origin HEAD` report zap permanently stale — a false positive no `zap update` could clear.

### Tests & docs
- `test(bubo)`: covers the probe classification logic against local fixture repos (offline, no live tooling required), including the two traps this report is built to avoid — the `cat-file -e` false-current trap and the non-default-branch false-stale trap.
- `docs(bubo)`: documents the staleness report and gives it its own `./scripts/run-tests bubo` category.

## Testing

- [x] `./scripts/run-tests bubo` — 18 tests pass (probe classification, offline/UNKNOWN handling, rendering)
- [x] `./scripts/lint-shell` — clean
- [x] Manually verified against the real system: zap now reports `CURRENT`, and the full report renders in fixed order across all surfaces

## Notes

The design rationale, measured probe costs, and the "probe state, don't track history" framing live in the issue and its validation comment. Two design invariants are worth calling out for review:

1. **Clone staleness compares HEAD SHAs, not object presence.** The obvious `git cat-file -e` check reports stale clones as current because an earlier fetch already pulled the object locally.
2. **Mason prints its registry data age.** The probe reads the cached registry, so it's only as honest as that cache is fresh; the age is surfaced next to the verdict.

Closes #236
