### PR TITLE
feat(claude): centralize the model-selection convention (taxonomy, board template, strategy doc, /model-triage)

### DIFF
--- a/claude/.claude/docs/label-taxonomy.md
+++ b/claude/.claude/docs/label-taxonomy.md
@@ -80,6 +80,27 @@ A unified vocabulary for classifying work across commits, branches, issues, and 
 | `docs` | `#0075CA` | Documentation changes |
 | `test` | `#BFD4F2` | Test-only changes |
 
+**Model labels** (one per issue — required alongside the type label, in repos that have adopted the convention):
+
+| Label | Color | Description |
+| --- | --- | --- |
+| `model: fable` | `#B60205` | Flagship build — reserve for subtle/multi-module correctness, silent-data-integrity stakes |
+| `model: opus` | `#FBCA04` | Workhorse build — well-scoped features, migrations/data-model, thin specs |
+| `model: sonnet` | `#0E8A16` | Light build — docs, single tests, i18n/copy, bounded pattern-following |
+
+The label records **which Claude model should build the issue**, assigned by asking what a _wrong answer_ costs and how far the reasoning reaches. Semantics, deliberately compact:
+
+- **Build tier only.** Review runs one tier above the build, and merge/reconcile decisions stay at Fable, per the standing model ladder. A cheap label never cheapens the safety net.
+- **Unlabeled = Opus** (fail-safe default) — so a missed label degrades to the workhorse tier, never to a cheaper one.
+- **The label is the source of truth**; a board `Model` field mirrors it for card visibility. If you change one, change the other.
+- **Assigned at creation, alongside the type label** — this is the second required labeling decision when an issue is opened, not a later cleanup pass. `/model-triage` exists to adopt the convention in a repo that already has open issues, and to sweep up drift; it is a backstop, not the primary mechanism.
+- **No tier on issues with nothing to build directly**: epics, trackers, content hubs, and `qa` reports (the derived tech issue carries the tier).
+- **Re-triage if an issue's scope materially changes.**
+
+This taxonomy is also the single place the current model _names_ live. When the lineup shifts, update the table here, then rename per-repo with `gh label edit` — the rename propagates to every issue already carrying the label.
+
+→ Judgment, calibration references, and the per-project rollout runbook: [`model-selection-strategy.md`](model-selection-strategy.md).
+
 **Triage labels** (optional, added during review):
 
 | Label | Color | Description |

--- a/claude/.claude/docs/model-selection-strategy.md
+++ b/claude/.claude/docs/model-selection-strategy.md
@@ -71,6 +71,26 @@ The label stopped being purely advisory once `/autopilot`, `/autopilot-batch`, a
 
 So a cheap label can only ever cheapen the _build_ — never the safety net that catches a cheap build's mistakes.
 
+### Which issues get no tier at all
+
+Some issues have nothing to build directly, and labeling them is noise that dilutes the signal:
+
+- **Epics and tracking issues** — the design brief, not the work. Their children carry the tiers.
+- **Content hubs** — a durable reference or index issue.
+- **`qa` reports** — a tester's observation, not a work item. The tech issue derived from it via `/qa-triage` carries the tier.
+
+Everything with code to write gets a tier. Re-triage when an issue's scope materially changes — a label recorded against a spec that has since doubled in scope is worse than no label, because it reads as considered judgment.
+
+### Keeping the label and the board field honest
+
+The label is the source of truth; the board's `Model` field mirrors it for card visibility (see the gotchas below on why both exist). Nothing syncs them automatically, so drift is expected. This one-liner finds every open issue that does not carry exactly one `model:` label:
+
+```bash
+gh issue list --state open --limit 200 --json number,labels --jq '[.[] | {n: .number, m: [.labels[].name | select(startswith("model"))]}] | map(select(.m | length != 1)) | map(.n)'
+```
+
+Any numbers returned are unlabeled — or double-labeled, which is the sneakier failure. Confirm each is a deliberate exclusion (epic / tracker / qa report), then spot-check the board field against the labels.
+
 ### No label → fall back to the existing heuristics
 
 Most repos have not adopted the convention and must keep working unchanged. When an issue carries no `model:` label, the skills use their own class rubric (Opus for data-model / security / ambiguous / cross-cutting work; Sonnet for bounded pattern-work). In an adopted repo, unlabeled means Opus by convention — which that rubric already approximates — so the same fallback is correct in both worlds and no skill needs a separate "is this repo adopted?" code path to choose a model.
@@ -105,10 +125,15 @@ Where an issue carries a top-of-body callout (layer 3), it usually names the wat
 - **The label and the field are independent** — nothing keeps them in sync automatically. Treat the **label as source of truth** and let the field mirror it; if you change one, change the other.
 - **Labels are per-repo; the field is per-board.** Recreate the three labels in each new repo (additive to the existing label taxonomy — they do not replace it). Create the `Model` field once per project board.
 - **An issue must be _on the board_** to receive a field value. `gh project item-list` only returns issues already added; add missing ones with `gh project item-add`.
+- **`gh issue view` / `gh issue edit` need `--repo` when run outside a repo checkout.** A rollout often runs from somewhere else (dotfiles, a scratch dir); without `--repo` the command either errors or, worse, silently targets whatever repo you happen to be standing in.
+- **Confirm every open issue is actually a board item _before_ the field pass.** `gh project item-list` returns only what has been added, so strays silently receive no field value. Diff the open-issue list against the item list and `gh project item-add` the gaps first.
+- **Trust `item-list`, not the issue body's claim about itself.** An issue whose body says it is deliberately off-board may well be on the board anyway. The board is the authority on board membership; a body is prose someone wrote once.
 
 ---
 
 ## Implementation runbook (copy-paste `gh` commands)
+
+> **Prefer `/model-triage`.** The skill encodes this runbook end-to-end — preflight, triage, an approval gate, apply, verify — and is the intended execution path for adopting the convention in a repo. The manual commands below remain the reference for what it does, for debugging a partial rollout, and for a one-off fix.
 
 Replace `<OWNER>` (e.g. your GitHub username), `<PROJECT_NUMBER>`, and the ID placeholders as you discover them.
 
@@ -193,9 +218,20 @@ gh issue view <N> --json body --jq .body | head -5                    # confirm 
 
 ---
 
-## Worked example (gg-songbook, 7 open issues)
+## Calibration references
 
-The concrete triage that produced **1 Flagship / 3 Workhorse / 3 Light** — a useful calibration reference for applying the heuristic:
+Two real triage passes, at very different scales. Use them to sanity-check a distribution before applying it — if your flagship share is far above these, the heuristic is probably being applied too generously.
+
+| Project | Issues | Fable | Opus | Sonnet | Flagship share |
+| --- | --- | --- | --- | --- | --- |
+| gg-songbook (2026-07) | 7 | 1 | 3 | 3 | ~14% (small-n) |
+| ComixDistro (2026-07-21) | 61 | 4 | 32 | 25 | **~6%** |
+
+ComixDistro is the more trustworthy anchor: at 61 issues the distribution has settled, and the shape is the point — **a small flagship reserve, a workhorse majority, and a substantial light tail**. The flagship tier is insurance, so a pass that tiers 20% of issues Fable has stopped discriminating and is just spending.
+
+### Worked example (gg-songbook, 7 open issues)
+
+The issue-by-issue reasoning behind the 1 / 3 / 3 above — a useful reference for how the heuristic reads in practice:
 
 | Issue | Kind | Tier | Reasoning |
 | --- | --- | --- | --- |

--- a/claude/.claude/docs/prd-workflow/spec-driven-development.md
+++ b/claude/.claude/docs/prd-workflow/spec-driven-development.md
@@ -273,6 +273,7 @@ This section maps every skill to its place in the development cycle. Think of it
 | `/bootstrap-prd` | Scaffold PRD structure for a new project | Once per project |
 | `/prd-view` | Render a PRD file as a rich HTML reading view (Dashboard style) for engaged reading and vetting; Markdown stays authoritative, the HTML is ephemeral | Ad-hoc (reading / vetting a spec) |
 | `/plan-phase` | Create GitHub issues from a PRD phase | Once per phase |
+| `/model-triage` | Adopt the per-issue model-selection convention — tier every open issue, apply the `model:` labels, board field, and callouts behind an approval gate; `--maintenance` sweeps drift | Once per project (then rarely) |
 | `/autopilot` | Carry one issue through the full dev loop autonomously — to a review-ready PR, or merge+deploy for small reversible changes (`--to merge`) | Per issue (unattended) |
 | `/autopilot-triage` | Vet open issues for autonomous resolution; queue the qualifying ones (`autopilot-queued`) | Per sprint (optional) |
 | `/autopilot-batch` | Fan out the queued issues to parallel worktree subagents, each running `/autopilot` | Per sprint (optional) |
@@ -407,6 +408,7 @@ Skills shift in importance as the project matures (see §6):
 | `/bootstrap-prd` | **Setup** | — | — |
 | `/prd-view` | **Spec vetting** | Occasional | Rare |
 | `/plan-phase` | **Every phase** | Rare (new features only) | — |
+| `/model-triage` | **Setup** (or on adoption) | Rare (drift sweep) | Rare (drift sweep) |
 | `/autopilot` | Optional | Useful (well-scoped issues) | Useful (well-scoped issues) |
 | `/autopilot-batch` | Optional | Useful for bug batches | Useful for bug batches |
 | `/resolve-issue` | **Primary workflow** | **Primary workflow** | **Primary workflow** |

--- a/claude/.claude/skills/autopilot-triage/SKILL.md
+++ b/claude/.claude/skills/autopilot-triage/SKILL.md
@@ -45,7 +45,7 @@ For each qualifying issue, also note — as a **preview**, not a commitment:
   gh label list --json name --jq '[.[].name | select(startswith("model: "))]'
   ```
 
-  A non-empty result means the repo has adopted the convention, so a queued issue without a `model:` label is a **triage gap** — worth fixing, but never a reason to skip the issue. The batch treats it as Opus by convention via the rubric. Do not apply the label yourself: model tiering is assigned when the issue is triaged, and quietly stamping a tier here would launder a guess into the record.
+  A non-empty result means the repo has adopted the convention, so a queued issue without a `model:` label is a **triage gap** — worth fixing, but never a reason to skip the issue. The batch treats it as Opus by convention via the rubric. Do not apply the label yourself: model tiering is assigned when the issue is triaged, and quietly stamping a tier here would launder a guess into the record. Point the gap at **`/model-triage --maintenance`**, which is the skill that owns that write.
 - **Merge-tier candidate?** — flag issues that look safe for `--to merge` (confined to config / locales / views / copy; no migration / route / dependency). These are _suggestions_ you opt into with `--merge` at run time; the batch defaults everything to `--to pr`.
 
 ## Your task
@@ -89,7 +89,7 @@ Skip:
   #870  needs a data-model decision (new column not in the schema)
   #872  spec ambiguous — two conflicting acceptance criteria
 
-Model-label gaps (adopted repo): #855 — label it at issue triage.
+Model-label gaps (adopted repo): #855 — run `/model-triage --maintenance` to fill it.
 ```
 
 **CONFIRM GATE:** This is the human gate the lifecycle requires — the label is applied **only after you confirm**. Present the proposed queue and wait. You may trim, add, or adjust a model call. Nothing is labeled before you say go.

--- a/claude/.claude/skills/model-triage/SKILL.md
+++ b/claude/.claude/skills/model-triage/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: model-triage
+description: Adopt the per-issue model-selection convention in a repo — tier every open issue, apply the model: labels, board field, and callouts behind an approval gate. Also runs in maintenance mode to sweep up unlabeled issues and label/field drift.
+disable-model-invocation: true
+argument-hint: "[--maintenance]"
+---
+
+# Model Triage
+
+Roll the per-issue model-selection convention into a repository: tier each open issue, then apply the `model:` labels, the board's `Model` field, and any body callouts — all behind a single approval gate. The convention, its heuristic, and the manual runbook this encodes live in `~/.claude/docs/model-selection-strategy.md`; the label vocabulary lives in `~/.claude/docs/label-taxonomy.md`.
+
+This is a **rollout tool, not a routine one.** Model labels are assigned at issue creation alongside the type label. Run this skill once when adopting the convention in a repo that already has open issues, and after that only in maintenance mode when drift has accumulated.
+
+## Where this runs
+
+From the **target repository's checkout** — you need the issues _and_ the code, because tiering an issue means judging what a fix would actually touch. If you must run from elsewhere, every `gh issue` call needs `--repo <owner>/<name>`; without it the command silently targets whatever repo you are standing in.
+
+## Arguments
+
+- **(no args)** — full rollout: tier every open issue that should carry a label.
+- **`--maintenance`** — sweep mode: tier only issues _missing_ a label, and reconcile label ↔ board-field drift. Leaves existing labels alone unless an issue's scope has visibly changed.
+
+## The tiering heuristic
+
+Assign a tier by asking what a _wrong answer_ costs and how far the reasoning reaches. Full treatment in the strategy doc; the working summary:
+
+- **Fable (flagship)** — a wrong answer would _silently_ corrupt canonical/persistent data, **or** the reasoning spans several modules with non-obvious ripple. This is the insurance case. Expect it rare, and expect each one to have a nameable reason.
+- **Opus (workhorse)** — well-specified features with a test scaffold and a contained blast radius; migrations / data-model; thin specs; security-adjacent work. The default when you genuinely can't tell.
+- **Sonnet (light)** — docs, a single regression test, i18n / copy, mechanical pattern-following where the spec leaves little to interpret and failure is visible.
+
+Lean one tier down for docs/tests, one tier up for anything touching data integrity.
+
+**Calibration:** ComixDistro's settled pass was 4 Fable / 32 Opus / 25 Sonnet across 61 issues — roughly **6% flagship**. If your pass lands far above that, you are not discriminating, you are just spending. Check the two calibration references in the strategy doc before presenting.
+
+### Issues that get no tier
+
+Some issues have nothing to build directly, and a tier on them is noise:
+
+- **epics and tracking issues** — the children carry the tiers
+- **content hubs** — durable reference/index issues
+- **`qa` reports** — the tech issue derived via `/qa-triage` carries the tier
+
+Call these out explicitly as deliberate exclusions rather than silently skipping them; an unexplained gap looks identical to an oversight.
+
+## Your task
+
+### Step 0 — Preflight
+
+Establish that everything the apply step needs exists, and stop early if it doesn't:
+
+1. **Token scope** — `gh auth status` must list `project` in the token scopes. If it's missing, stop: the user must run `gh auth refresh -s project` interactively. You cannot grant it for them.
+2. **Locate the board** — `gh project list --owner <OWNER>`; capture the project number and node ID (`PVT_…`). If the repo has no board, the label pass can still proceed — say so and skip the field work rather than stopping.
+3. **Labels exist** — `gh label list`. Create any missing ones from the taxonomy, exactly as specified there:
+
+   ```bash
+   gh label create "model: fable"  --color B60205 --description "Recommended model: Fable 5 (reserve for subtle/multi-module correctness)"
+   gh label create "model: opus"   --color FBCA04 --description "Recommended model: Opus 4.8 (well-scoped features, refactors)"
+   gh label create "model: sonnet" --color 0E8A16 --description "Recommended model: Sonnet (docs, single tests, mechanical edits)"
+   ```
+
+4. **`Model` field exists** — `gh project field-list <N> --owner <OWNER> --format json`. If absent, create it once:
+
+   ```bash
+   gh project field-create <N> --owner <OWNER> \
+     --name "Model" --data-type SINGLE_SELECT --single-select-options "Fable,Opus,Sonnet"
+   ```
+
+5. **Board membership** — `gh project item-list <N> --owner <OWNER> --limit 200 --format json`. Diff against the open-issue list; **an issue not on the board cannot receive a field value.** Note the strays now so the apply step can `gh project item-add` them first. Trust `item-list` over any claim an issue body makes about its own board membership.
+
+Report the preflight result compactly: what existed, what you created, what needs adding to the board.
+
+### Step 1 — Gather
+
+- `gh issue list --state open --limit 200 --json number,title,labels,body`.
+- In `--maintenance` mode, narrow to issues with no `model:` label — plus any whose scope has visibly changed since labeling.
+
+### Step 2 — Tier
+
+Read each issue's body and, where scope is unclear, the code a fix would touch. For each, decide:
+
+- its **tier**, with a one-line reason grounded in the heuristic (what a wrong answer costs / how far the reasoning reaches);
+- whether it is a **deliberate exclusion** (epic / tracker / hub / qa report);
+- whether it warrants a **body callout** — only where the tier choice carries real nuance a bare label cannot convey, e.g. "workhorse, but escalate _this specific sub-problem_ to flagship if it gets gnarly." Plain light-tier docs issues need none. A callout on every issue is a callout on none.
+
+Note anything else the pass turns up — duplicates, already-shipped work, issues whose spec has drifted from the code. A careful read of every open issue surfaces this whether you want it or not, and it is worth more than the tiering.
+
+### Step 3 — Present + APPROVAL GATE
+
+Present the full mapping before touching anything:
+
+```text
+Tiering — 23 issues (2 Fable / 12 Opus / 9 Sonnet)
+
+  #58   Fable   chord_only_line? has four dependents; a miss silently corrupts song files
+  #49   Opus    --transpose; test scaffold exists, contained. Watch: enharmonic spelling
+  #50   Sonnet  docs over a settled pipeline, no correctness stakes
+  …
+
+Excluded (no tier, deliberate):
+  #12   epic — children carry the tiers
+  #77   qa report — derived tech issue carries the tier
+
+Proposed callouts (3):
+  #49   "Opus, but escalate the enharmonic-spelling logic to Fable if it proves gnarly"
+  …
+
+Also noticed:
+  #61   appears to duplicate #44
+  #83   spec references a helper that no longer exists
+
+Board: 2 open issues are not board items (#71, #84) — will add before the field pass.
+```
+
+**STOP for explicit approval.** Nothing is labeled, no field is set, and no body is edited before the user says go. They may retier anything, drop callouts, or expand the exclusions. This gate is the whole safety model of the skill: it writes to every open issue in the repo, and a bad pass is tedious to unwind.
+
+### Step 4 — Apply
+
+Only after approval, in this order:
+
+1. **Board strays first** — `gh project item-add <N> --owner <OWNER> --url <issue-url>` for each, or their field values silently no-op.
+2. **Labels** — `gh issue edit <n> --add-label "model: <tier>"`.
+3. **Field values** — collect the field ID and option IDs (`gh project field-list … --format json`) and the item IDs (`gh project item-list … --format json`), then per issue:
+
+   ```bash
+   gh project item-edit --id <ITEM_ID> --project-id <PROJECT_NODE_ID> \
+     --field-id <MODEL_FIELD_ID> --single-select-option-id <OPTION_ID>
+   ```
+
+4. **Callouts** — **round-trip the body, never retype it.** Fetch, prepend, write back:
+
+   ```bash
+   gh issue view <n> --json body --jq .body > /tmp/body.md
+   # build /tmp/head.md: the callout blockquote, a blank line, ---, a blank line
+   cat /tmp/head.md /tmp/body.md > /tmp/final.md
+   gh issue edit <n> --body-file /tmp/final.md
+   ```
+
+   Callout template:
+
+   ```markdown
+   > **🤖 Recommended model: <Model>.** <One sentence: why this tier, and the single watch-item or escalation trigger if any.>
+   ```
+
+5. **Board README** — if the board's README has no "Model = recommended build tier" section, append it. The settled wording lives in the ComixDistro board #11 README; the template board carries it for new projects.
+
+### Step 5 — Verify
+
+- Run the drift check and confirm the only issues returned are the approved exclusions:
+
+  ```bash
+  gh issue list --state open --limit 200 --json number,labels --jq '[.[] | {n: .number, m: [.labels[].name | select(startswith("model"))]}] | map(select(.m | length != 1)) | map(.n)'
+  ```
+
+- Spot-check a few board cards against their labels, and one edited body to confirm the callout landed with the original text intact below it.
+- Report the final distribution (`N Fable / N Opus / N Sonnet`, flagship share) and how it compares to the calibration references.
+
+## Important
+
+- **The approval gate is a hard stop.** This skill writes labels, board fields, and issue bodies across an entire repo. Nothing is applied speculatively.
+- **Never retype an issue body.** Callouts are prepended to a round-tripped body via `--body-file`. Retyping loses content, and the loss is silent.
+- **The label is the source of truth; the field mirrors it.** If they disagree, the label wins — fix the field.
+- **This is a backstop, not the primary mechanism.** Model labels belong at issue creation, alongside the type label. If maintenance mode keeps finding large numbers of unlabeled issues, the fix is upstream at issue creation, not more frequent sweeps — say so in the report rather than quietly re-sweeping.
+- **Flag what the read surfaces.** Tiering requires reading every open issue closely, which reliably turns up duplicates and stale specs. Report them; that byproduct is often worth more than the labels.


### PR DESCRIPTION
## Summary

- Centralizes the per-issue model-selection convention in dotfiles so existing projects can adopt it cheaply and new projects inherit it for free — vocabulary into the label taxonomy, board structure into the template board, judgment into the strategy doc, and the rollout runbook into a new `/model-triage` skill.
- Records the creation-time rule that nothing in the workflow enforced: a `model:` label is assigned when an issue is opened, alongside the type label. `/model-triage` is the adoption/drift backstop, not the primary mechanism.
- Companion to #239 (autopilot skills consume the label). Between them the *automated* consumer path is complete; #242 covers the interactive one.

## Changes

**Docs**

- `docs(labels)` — `label-taxonomy.md` gains the Model labels group, placed **beside the type labels** rather than in its own group further down, because placement teaches the rule: it is the second required labeling decision at creation. Carries the compact semantics (build-tier-only, unlabeled = Opus, label is source of truth, no-tier exclusion classes, re-triage on scope change) and is the single place the current model *names* live.
- `docs(claude)` — `model-selection-strategy.md` folds in the ComixDistro rollout learnings: no-tier exclusion classes, the drift-check one-liner, three rollout gotchas, and a calibration section carrying both passes. Recasts the single worked example as two calibration references.
- `docs(prd-workflow)` — `/model-triage` added to the handbook skill map, in **both** tables (library + lifecycle-stage mapping).

**Skills**

- `feat(claude)` — new `/model-triage`: preflight → triage → approval gate → apply → verify, plus `--maintenance` sweep mode. `disable-model-invocation: true`.
- `feat(claude)` — `/autopilot-triage`'s model-label gap flag now routes to `/model-triage --maintenance`, the skill that owns that write.

**Remote — not in git (see Notes)**

- Board #12 (`[TEMPLATE] <project-name> Development`): added the `Model` single-select field (`Fable`/`Opus`/`Sonnet`) and appended the "Model = recommended build tier" README section. README went 1,336 → 3,202 chars; opening line corrected `Two` → `Three independent axes`.

## Testing

- [x] `./scripts/lint-shell` — clean (45 scripts)
- [x] `./scripts/run-tests` — 106/106 pass
- [x] `markdownlint-cli2` via pre-commit — clean
- [x] Board #12 verified post-change: `Model` field present with correct options; README Model section present; Status / Track / One-priority-system sections all intact

**Caveat:** Markdown and remote board state, with no automated coverage. The suite guards against regressions elsewhere in the repo; it does not exercise this change.

## Notes

**Two deliverables live on GitHub, not in this repo.** The board #12 field and README are real changes this PR cannot capture and git cannot revert. Reverting the commits here would leave the template board carrying a `Model` field with nothing in dotfiles explaining it. To unwind fully: delete the field via the board UI and restore the README to its pre-change 1,336-char form.

**AC #2 is half-verified, deliberately.** Scope item 2 also asked to "verify on the next project spin-up that copies inherit field + README as expected." No spin-up is pending, so that is untested — the box reflects "field and README added," not "inheritance confirmed." Worth checking at the next new project.

**`/model-triage` is a new skill rather than a mode of `/autopilot-triage`** — a call worth recording, since #219 landed on "evolution not revolution" for exactly this kind of question. They share a shape (iterate open issues, gate, apply a label) but answer different questions: `/autopilot-triage` asks "can this run unattended?" over the autonomous subset; `/model-triage` asks "how much horsepower does this need?" over every issue, including ones a human will build. It also writes board fields, issue bodies, and a board README, which `/autopilot-triage` never touches. Merging them would have produced one skill with two rubrics and two output shapes.

**The creation-time gap is real and now documented but not yet implemented.** No issue-creating surface assigns a `model:` label today — `/plan-phase` applies no labels at all, not even type; `/qa-triage` and `/qa-triage-batch` apply type only. Without closing that, every issue opened after a rollout is unlabeled, falls back to Opus, and the tiered distribution dilutes back to the pre-convention status quo with no visible failure. This PR states the rule; **#243** implements it. `/dustoff` is correctly left alone — its tracking issue is a no-tier exclusion class.

**File-conflict note for #242.** That issue adds a *human-consumer* section to `model-selection-strategy.md` — launcher usage, settings precedence, the `/model` and `/effort` persistence traps, the `[1m]` zsh-glob trap. Different sections, same file, and genuinely complementary: the section this PR extends is scoped to the automated path ("how the autopilot skills read the label"), leaving room for its interactive counterpart. Whoever picks up #242 should **re-read the file rather than work from the issue text** — it has now grown by roughly 90 lines across two PRs and its issue description is stale relative to it.

Closes #240
Refs #242
Refs #243
