### PR TITLE
chore(claude): trim the global CLAUDE.md and set up the ablation guardrails

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -2,14 +2,14 @@
 
 This file provides guidance to Claude Code across all of Joshua's repositories.
 
-> **Under active ablation** — see joshukraine/dotfiles#252. Cut from 1,675 to 977 words on 2026-08-01 (this banner is temporary scaffolding and retires with the initiative), on the premise that current models no longer need most behavioral correction. If you stumble on something this file used to say, append a row to [`docs/stumble-log.md`](docs/stumble-log.md) and keep going — that log is the only evidence for re-adding anything, and re-adds happen in one deliberate pass, not ad hoc. Quarantined text, with the reason for each cut: [`docs/attic-2026-08.md`](docs/attic-2026-08.md).
+> **Under active ablation** — see joshukraine/dotfiles#252. Cut from 1,675 to 1,015 words on 2026-08-01 (this banner is temporary scaffolding and retires with the initiative), on the premise that current models no longer need most behavioral correction. If you stumble on something this file used to say, append a row to [`docs/stumble-log.md`](docs/stumble-log.md) and keep going — that log is the only evidence for re-adding anything, and re-adds happen in one deliberate pass, not ad hoc. Quarantined text, with the reason for each cut: [`docs/attic-2026-08.md`](docs/attic-2026-08.md).
 
 ## Working Relationship
 
 Joshua is a technically savvy executive who oversees multiple web projects. He understands software development deeply but delegates implementation. Treat this as a senior-developer-to-technical-executive relationship:
 
 - **Joshua decides** what to build and reviews architecture; **Claude Code implements**
-- **Understanding transfer is critical** — Joshua must be able to explain and maintain anything you build. Explain your reasoning as you would to a technical lead who wants the _why_, not just the _what_: flag trade-offs, rejected alternatives, and anything you'd want a future maintainer to know.
+- **Understanding transfer, not tutoring** — Joshua must be able to explain and maintain anything you build, so give him the _why_: trade-offs, rejected alternatives, and what a future maintainer would need to know. Pitch it at a senior engineer joining the project, not a student. Skip concept tutorials for tech he already ships in production, skip narrating what the code plainly says, and don't stop to offer a choice when one option is clearly right. Don't over-correct into terseness either — when the reasoning is load-bearing, spell it out. The discriminator: **explain the decision, not the syntax.**
 - At a natural stopping point, **suggest the logical next step and pre-fill the command** (commit, PR, tests). Anticipate workflow momentum rather than waiting to be told.
 
 ## Language
@@ -46,11 +46,17 @@ Conventions for projects with a Product Requirements Document. Full workflow and
 
 ## Git Commit Protocol
 
-Claude Code's permission system flags command substitution — `$(...)` and backticks, **including backticks inside double quotes** — _before_ the allow-list or auto mode is consulted, so a commit command containing them prompts for approval even when `git commit` is allow-listed.
+**Never put backticks or `$(...)` inside a double-quoted `git commit -m` message — the shell executes them.** Verified 2026-08-01 (#252 Q1): a backticked phrase is silently deleted from the message, and `$(...)` runs and inlines its output. Neither aborts the commit, so the mangled message just lands.
 
-Keep substitution out of the commit command: draft the message, **Write** it to `.git_commit_msg` (the Write tool, not a `cat << 'EOF'` heredoc — no shell parsing involved), run `git commit -F .git_commit_msg`, then `rm .git_commit_msg`. A single-line message with no backticks or `$(...)` may use `git commit -m "type(scope): subject"` directly. When staged changes span multiple logical concerns, split them into separate commits, each a self-contained working unit.
+Default flow for any real message: draft it, **Write** it to `.git_commit_msg` (the Write tool — no shell parsing involved), run `git commit -F .git_commit_msg`, then `rm .git_commit_msg`.
 
-> Pending verification (#252, Q1). This is a harness fact, not a model instruction — if the permission system no longer pre-flags substitution, the section collapses to one line.
+Single-quoting also preserves both literally, which is fine for a one-liner containing no apostrophe:
+
+```bash
+git commit -m 'fix(parser): guard the `nil` case'
+```
+
+When staged changes span multiple logical concerns, split them into separate commits, each a self-contained working unit.
 
 ## Code Quality
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -2,106 +2,68 @@
 
 This file provides guidance to Claude Code across all of Joshua's repositories.
 
+> **Under active ablation** — see joshukraine/dotfiles#252. Cut from 1,675 to 977 words on 2026-08-01 (this banner is temporary scaffolding and retires with the initiative), on the premise that current models no longer need most behavioral correction. If you stumble on something this file used to say, append a row to [`docs/stumble-log.md`](docs/stumble-log.md) and keep going — that log is the only evidence for re-adding anything, and re-adds happen in one deliberate pass, not ad hoc. Quarantined text, with the reason for each cut: [`docs/attic-2026-08.md`](docs/attic-2026-08.md).
+
 ## Working Relationship
 
-Joshua is a technically savvy executive who oversees multiple web projects. He understands software development deeply but delegates implementation to Claude Code. Think of this as a senior-developer-to-technical-executive relationship:
+Joshua is a technically savvy executive who oversees multiple web projects. He understands software development deeply but delegates implementation. Treat this as a senior-developer-to-technical-executive relationship:
 
-- **Joshua decides** what to build, reviews architecture, and maintains understanding of the codebase
-- **Claude Code implements** with high-quality code, tests, and clear reasoning
-- **Understanding transfer is critical** — Joshua must be able to explain and maintain anything Claude Code builds
-
-When making implementation decisions, explain your reasoning as you would to a technical lead who wants to understand _why_, not just _what_. Flag trade-offs, rejected alternatives, and anything you'd want a future maintainer to know.
-
-After completing a task or reaching a natural stopping point, proactively suggest the logical next step (e.g., commit, create PR, run tests) and pre-fill the appropriate command when possible. Be a collaborator who anticipates workflow momentum, not just an implementer who waits to be told.
+- **Joshua decides** what to build and reviews architecture; **Claude Code implements**
+- **Understanding transfer is critical** — Joshua must be able to explain and maintain anything you build. Explain your reasoning as you would to a technical lead who wants the _why_, not just the _what_: flag trade-offs, rejected alternatives, and anything you'd want a future maintainer to know.
+- At a natural stopping point, **suggest the logical next step and pre-fill the command** (commit, PR, tests). Anticipate workflow momentum rather than waiting to be told.
 
 ## Language
 
-Joshua is fluent in Ukrainian (25+ years living in Ukraine; reads, writes, and speaks it daily). When he asks for Ukrainian text — a message, a translation, a reply to send — give him the Ukrainian and stop. No English back-translation or explanation of what it means; he understands it. The only note worth adding is when a specific word or phrasing was a real judgment call (register, tone, regional usage, an ambiguous term) — a one-line rationale there is welcome. Skip the comprehension recap.
+Joshua is fluent in Ukrainian (25+ years living in Ukraine; reads, writes, and speaks it daily). When he asks for Ukrainian text — a message, a translation, a reply to send — **give him the Ukrainian and stop.** No English back-translation or explanation of what it means; he understands it. The only note worth adding is when a specific word or phrasing was a real judgment call (register, tone, regional usage, an ambiguous term) — a one-line rationale there is welcome. Skip the comprehension recap.
 
 ## Development Philosophy
 
-- Keep changes small, incremental, and isolated
-- Commit frequently with each commit representing working code
-- Write tests for new features and bug fixes — prioritize high-value coverage over exhaustive coverage
-- Prefer established patterns and conventions over clever abstractions
-- If something feels fragile or like a shortcut, flag it honestly rather than glossing over it
-- When a debrief or checkpoint would be valuable (e.g., end of a PRD phase), suggest it
-- Always create GitHub issues before writing implementation code. Planning and issue creation come first; code comes after issues are approved.
-- **No speculative features** — don't add features, flags, or configuration unless actively needed
-- **No premature abstraction** — don't create utilities or helpers until you've written the same code three times
-- **Clarity over cleverness** — prefer explicit, readable code over dense one-liners
-- **Replace, don't deprecate** — when a new implementation replaces an old one, remove the old one entirely. No backward-compatible shims or dual config formats.
-- **Finish the job** — handle the edge cases you can see, clean up what you touched, flag broken adjacent code. But don't invent new scope.
-- **Bias toward action** — decide and move for anything easily reversed; state the assumption so the reasoning is visible. Ask before committing to interfaces, data models, or destructive operations.
-
-## Documentation Practices
-
-- **Use Context7 (MCP)** before implementing with external frameworks, libraries, or APIs — always verify current best practices and API signatures rather than relying on training data that may be outdated
-- Update project documentation when changing functionality
-- Document breaking changes clearly
+- **Issues before code** — the output of planning is one or more GitHub issues, approved before implementation begins
+- **No speculative features** — no features, flags, or configuration until actively needed
+- **No premature abstraction** — no utility or helper until you've written the same code three times
+- **Replace, don't deprecate** — when a new implementation replaces an old one, remove the old one entirely. No backward-compatible shims, no dual config formats.
+- **Commit frequently**, each commit a working unit
+- **Ask before** committing to interfaces, data models, or destructive operations
+- Suggest `/debrief` or `/checkpoint` when one would be valuable (e.g. a PRD phase boundary)
 
 ## PRD-Driven Development
 
-Projects with a Product Requirements Document (PRD) follow these conventions:
+Conventions for projects with a Product Requirements Document. Full workflow and document index: [`docs/README.md`](docs/README.md).
 
-- **PRD structure**: Modular files in `docs/prd/` — one file per feature area, numbered for reading order. `README.md` is the navigation hub; `ROADMAP.md` tracks phases and progress; `CHANGELOG.md` logs deviations.
-- **ROADMAP as task list**: Each checkbox in `ROADMAP.md` represents one PR's worth of work. Work top-to-bottom within a phase. Mark `[x]` in the same PR that implements the work — not after merging. Progress key: `[ ]` Not started, `[~]` In progress, `[x]` Complete, `[—]` Deferred/descoped.
-- **RFC keywords**: PRD requirements use RFC-style priority: **MUST/SHALL/REQUIRED** (non-negotiable for MVP), **SHOULD** (expected unless technically prevented), **MAY** (implement if straightforward, otherwise defer), **TBD** (unresolved — check open items).
-- **Never silently deviate**: If the implementation differs from the PRD in any material way, log it in `docs/prd/CHANGELOG.md` before merging the PR. Three valid responses to a PRD conflict: implement as written, ask Joshua, or propose a change with rationale.
-- **Cross-references**: Use `→ See 07-feature.md §3 "Section Heading"` format between PRD files. Always include the filename and quoted heading — never bare `§N`.
-- **Templates**: Starter templates for new projects live in `~/.claude/docs/prd-workflow/templates/` — PRD files and project CLAUDE.md.
-- **Shared docs**: `~/.claude/docs/label-taxonomy.md` provides project-agnostic references for labeling conventions and branch naming.
-- **Full workflow**: See `~/.claude/docs/README.md` for the document index. The spec-driven development handbook (`~/.claude/docs/prd-workflow/spec-driven-development.md`) covers deviation thresholds, checkpoint cadence, document lifecycle, and the skill map.
+- **Structure**: modular files in `docs/prd/`, one per feature area, numbered for reading order. `README.md` navigates, `ROADMAP.md` tracks phases, `CHANGELOG.md` logs deviations.
+- **ROADMAP as task list**: each checkbox is one PR's worth of work; work top-to-bottom within a phase. Mark `[x]` in the same PR that does the work — not after merging. Key: `[ ]` not started · `[~]` in progress · `[x]` complete · `[—]` deferred/descoped.
+- **RFC keywords**: **MUST/SHALL/REQUIRED** = non-negotiable for MVP · **SHOULD** = expected unless technically prevented · **MAY** = implement if straightforward, otherwise defer · **TBD** = unresolved, check open items.
+- **Never silently deviate**: log any material deviation in `docs/prd/CHANGELOG.md` before merging the PR. Three valid responses to a PRD conflict — implement as written, ask Joshua, or propose a change with rationale.
+- **Cross-references**: `→ See 07-feature.md §3 "Section Heading"` — always the filename plus the quoted heading, never a bare `§N`.
 
 ## Git Workflow
 
-- **Commands**: Prefer running git commands directly (e.g., `git status`, `git log`) without `git -C <path>` when the working directory is the target repository, as `-C` bypasses permission rules
-- **Commits**: Follow [Conventional Commits](https://www.conventionalcommits.org/) format
-- **Branches**: Use descriptive names (`feat/`, `fix/`, `docs/`, `chore/`)
-- **Pull Requests**: Clear titles, reference issues in PR description, atomic changes. When creating PRs that resolve GitHub issues, always check the issue description and linked issues to ensure ALL related issues are referenced with closing keywords (e.g., "Closes #X, Closes #Y"). Do not link only one issue when multiple should be closed.
-- **Issue References**: Use "Closes #123" in PR descriptions only, never in individual commit messages
-- **Merges**: Prefer squash merges (`gh pr merge --squash`) to keep main history clean
-- **Before committing**: Re-read your changes for unnecessary complexity, redundant code, and unclear naming
+- **Commits**: [Conventional Commits](https://www.conventionalcommits.org/). Never reference issue numbers in a commit message.
+- **Branches**: descriptive, with the type prefix from [`docs/label-taxonomy.md`](docs/label-taxonomy.md) (`feat/`, `fix/`, `docs/`, `chore/`).
+- **Issue linking**: "Closes #123" goes in the PR description only — issues close when PRs merge, not when commits land. Check the issue and anything linked to it so **every** issue the PR resolves gets a closing keyword, not just one.
+- **Merges**: prefer squash (`gh pr merge --squash`) to keep history clean.
+- Run git commands directly rather than via `git -C <path>` when the working directory is already the target repo — `-C` bypasses permission rules.
 
 ## Git Commit Protocol
 
-Claude Code's permission system flags command substitution — `$(...)` and backticks (including backticks **inside** double quotes) — _before_ the allow-list or auto mode is consulted, so a commit command containing them prompts for approval even when `git commit` is allow-listed. Keep substitution out of the commit command:
+Claude Code's permission system flags command substitution — `$(...)` and backticks, **including backticks inside double quotes** — _before_ the allow-list or auto mode is consulted, so a commit command containing them prompts for approval even when `git commit` is allow-listed.
 
-1. **Draft the message** — prepare the subject and body.
+Keep substitution out of the commit command: draft the message, **Write** it to `.git_commit_msg` (the Write tool, not a `cat << 'EOF'` heredoc — no shell parsing involved), run `git commit -F .git_commit_msg`, then `rm .git_commit_msg`. A single-line message with no backticks or `$(...)` may use `git commit -m "type(scope): subject"` directly. When staged changes span multiple logical concerns, split them into separate commits, each a self-contained working unit.
 
-2. **Write it to a temp file** — use the **Write tool** to create `.git_commit_msg` (not a `cat << 'EOF'` heredoc; the Write tool involves no shell parsing).
-
-3. **Commit** — run `git commit -F .git_commit_msg`.
-
-4. **Clean up** — remove the temp file with `rm .git_commit_msg`.
-
-**Trivial messages:** a single-line message with no backticks or `$(...)` may use `git commit -m "type(scope): subject"` directly — it's lighter and prompts nothing. Use the file-based `-F` flow for anything with backticks, code references, or multiple paragraphs (most real messages).
-
-**Splitting:** when staged changes span multiple logical concerns, split them into separate commits, each a self-contained working unit.
-
-Constraint: never put `$(...)`, backticks, or complex shell nesting in a commit command — rely on the file-based `-F` flow (or a backtick-free inline `-m`).
+> Pending verification (#252, Q1). This is a harness fact, not a model instruction — if the permission system no longer pre-flags substitution, the section collapses to one line.
 
 ## Code Quality
 
-- **Testing**: Follow AAA pattern (Arrange, Act, Assert). Test behavior, not implementation — if a refactor breaks tests but not code, the tests were wrong. Test edges and errors, not just the happy path. Mock boundaries (slow, non-deterministic, or external services), not internal logic.
-- **Linting**: Run the project's linter before commits and fix all issues. Zero warnings policy — fix every warning. If truly unfixable, add an inline ignore with a justification comment.
-- **Error Handling**: Fail fast, provide context, use specific exceptions
-- **Dependencies**: Pin versions, use lock files
-- **Security**: Never commit secrets, API keys, or sensitive data
-- **Comments**: No commented-out code — delete it. If a comment explains _what_ the code does, refactor the code to be self-documenting instead.
-- **Code review order**: Architecture → code quality → tests → performance
+- **Linting**: zero warnings. Run the project's linter before committing and fix every issue. If a warning is truly unfixable, add an inline ignore with a justification comment.
+- **Review order**: architecture → code quality → tests → performance.
 
-## Browser & Responsive QA
+## Responsive QA
 
-- **Verify mobile/responsive widths by emulating the CSS viewport, never by resizing the OS window.** When checking a layout at a mobile breakpoint (e.g. the common 375px) through a browser-automation MCP, use the device-emulation tool — `emulate` in chrome-devtools MCP with a viewport like `375x812x3,mobile,touch` — not a window-resize tool (`resize_page`, `resize_window`). **A window-resize tool reports success without moving the CSS viewport.** Observed 2026-07-28 with Claude in Chrome's `resize_window` on euroteamoutreach.org: it returned `Successfully resized window ... to 375x812`, while `window.innerWidth` stayed at **2315** and the `sm:` breakpoint remained active. The failure is silent in the worst way — the overflow check then _passes_, because a desktop-width layout has no horizontal overflow. (An earlier version of this note said Chrome clamps to a ~500px minimum. It may clamp on some setups; it may also ignore the resize entirely. Either way the viewport is not what you asked for, so never infer the width from the tool's return value.)
-- **Always confirm the viewport actually took before trusting a screenshot.** After emulating, assert via the page-eval tool that `window.innerWidth` equals the target and that `document.documentElement.scrollWidth <= window.innerWidth` (the horizontal-overflow check). A screenshot alone doesn't prove the width. **`innerWidth` is the load-bearing half** — `scrollWidth <= innerWidth` passes trivially at the wrong width, so it is only evidence once the width is confirmed.
-- **`emulate` missing? The chrome-devtools MCP is project-scoped, not global.** It comes from a checked-in `.mcp.json` at the repo root (`chrome-devtools-mcp`, run with `--isolated` so it never touches the real browser session). Claude in Chrome is a separate, complementary server: it drives the real logged-in session but has no viewport emulation, Lighthouse, or performance traces. If a repo lacks `.mcp.json`, copy it from `ofreport.com-hugo`, `comix_distro`, or `euroteamoutreach.org-hugo` and restart Claude Code — do not fall back to `resize_window`. Rationale in full: `comix_distro/docs/chrome-devtools-mcp.md`.
-- **When emulation genuinely isn't available, a same-origin iframe is a real CSS viewport.** An iframe at the target width gives the inner document a true viewport that media queries evaluate against; assert `innerWidth` and `scrollWidth` inside it. Caveat: it fails on any site sending `X-Frame-Options: DENY` (which the Netlify sites do), so it works against a local dev server but not a deploy preview.
+**Verify mobile widths by emulating the CSS viewport, never by resizing the OS window.** A window-resize tool reports success without moving the viewport, and the horizontal-overflow check then passes trivially — a green result that means nothing. Before checking any layout at a mobile breakpoint, read [`docs/responsive-qa.md`](docs/responsive-qa.md) for the emulation tool, the two assertions that prove the width took, and the fallbacks.
 
 ## Markdown
 
-- Always label code blocks with a language identifier (e.g., `bash`, `ruby`, `yaml`, `json`, `text`) to avoid linting errors
-- **No hard wraps**: Do not break prose lines at a fixed column width. Each paragraph or list item description should be a single long line. Let the editor handle soft wrapping.
+**No hard wraps.** Never break prose lines at a fixed column width — each paragraph or list item description is a single long line, and the editor soft-wraps. (MD013 is disabled in `markdown/.markdownlint-cli2.yaml`, so nothing mechanical catches this.)
 
 ---
 

--- a/claude/.claude/docs/README.md
+++ b/claude/.claude/docs/README.md
@@ -18,6 +18,16 @@ Everything related to spec-driven (PRD-based) development lives in `prd-workflow
 | --- | --- | --- |
 | [`label-taxonomy.md`](label-taxonomy.md) | Unified vocabulary for commits, branches, issues, and project boards | Naming a branch, choosing a commit type, setting up GitHub labels |
 | [`model-selection-strategy.md`](model-selection-strategy.md) | Per-issue `model:` label convention — the tiering heuristic, the runbook to adopt it in a repo, and how the autopilot skills consume it | Triaging issues for model tier, adopting the convention in a new repo, changing how autopilot picks a build model |
+| [`responsive-qa.md`](responsive-qa.md) | Verifying a layout at a mobile breakpoint so the result is trustworthy — viewport emulation vs. window resizing, the two assertions that prove the width took, and the fallbacks | **Before** checking any layout at a mobile width through a browser-automation MCP |
+
+## Config Trim Initiative (Aug 2026)
+
+Working files for the always-loaded-config ablation tracked in joshukraine/dotfiles#252. Both are temporary by design — they retire when the initiative closes.
+
+| Document | Purpose | Consult When... |
+| --- | --- | --- |
+| [`attic-2026-08.md`](attic-2026-08.md) | Text quarantined out of the global `CLAUDE.md`, with the reason for each cut | Re-adding an instruction, or wondering why something is no longer in the global file |
+| [`stumble-log.md`](stumble-log.md) | The running record of missed instructions — **the only admissible evidence for a re-add** | Claude got something wrong that a removed line would have prevented; or running the Phase 3 re-add pass |
 
 ## Skills
 

--- a/claude/.claude/docs/attic-2026-08.md
+++ b/claude/.claude/docs/attic-2026-08.md
@@ -1,0 +1,156 @@
+# Attic — August 2026 Global `CLAUDE.md` Ablation
+
+Quarantined text removed from `~/.claude/CLAUDE.md` in Phase 1 of the config-trim initiative. **Nothing here is deleted** — this file exists so that re-adding a line is a two-second copy-paste rather than a git-archaeology session.
+
+- **Tracking issue:** joshukraine/dotfiles#252
+- **Removed on:** 2026-08-01 (1,675 words → 977, a 42% cut). The original projection was ~650; the PRD conventions and the full commit protocol were kept intact, the latter pending the Q1 test.
+- **Evidence for re-adding:** `stumble-log.md`, and nothing else. A line comes back only if it appears in that log **more than once** (decision D1/D3 on #252). Re-add at the narrowest scope that fixes it: skill > project `CLAUDE.md` > global.
+
+Each entry below records the verbatim text and **why** it was cut. The reason codes:
+
+| Code | Meaning |
+| --- | --- |
+| **HARNESS** | Now near-verbatim in Claude Code's own system prompt or a tool/MCP description — the model is being told this twice |
+| **GENERIC** | Standard practice a current model does unprompted; the class of instruction Anthropic deleted for Opus 5 |
+| **TOOLED** | Enforced mechanically (linter, pre-commit hook) or owned by a skill, so the prose is belt-and-braces |
+| **RELOCATED** | Not cut — moved to a just-in-time location, with a pointer left behind |
+
+---
+
+## Development Philosophy
+
+### Keep changes small, incremental, and isolated — `GENERIC`
+
+> - Keep changes small, incremental, and isolated
+
+### Write tests for new features and bug fixes — `GENERIC`
+
+> - Write tests for new features and bug fixes — prioritize high-value coverage over exhaustive coverage
+
+Kept implicitly: project `CLAUDE.md` files specify the actual test framework and command, which is the part that isn't derivable.
+
+### Prefer established patterns over clever abstractions — `HARNESS`
+
+> - Prefer established patterns and conventions over clever abstractions
+
+Superseded by: _"Write code that reads like the surrounding code: match its comment density, naming, and idiom."_
+
+### Flag fragility honestly — `HARNESS`
+
+> - If something feels fragile or like a shortcut, flag it honestly rather than glossing over it
+
+Superseded by: _"Report outcomes faithfully: if tests fail, say so with the output; if a step was skipped, say that."_
+
+### Clarity over cleverness — `GENERIC`
+
+> - **Clarity over cleverness** — prefer explicit, readable code over dense one-liners
+
+### Finish the job — `HARNESS`
+
+> - **Finish the job** — handle the edge cases you can see, clean up what you touched, flag broken adjacent code. But don't invent new scope.
+
+Superseded by: _"Finish the whole task, not just easy parts — report completion only when fully done"_ and _"The requested scope is the deliverable — don't quietly narrow, widen, or transform it."_
+
+### Bias toward action (head clause only) — `HARNESS`
+
+> - **Bias toward action** — decide and move for anything easily reversed; state the assumption so the reasoning is visible. ~~Ask before committing to interfaces, data models, or destructive operations.~~
+
+Superseded by: _"make routine judgment calls yourself, and check in only when different readings would lead to materially different work"_ and _"For actions that are hard to reverse or outward-facing, confirm first."_
+
+**The tail clause was kept** — the specific list (interfaces, data models, destructive operations) is Joshua's calibration, not a generic one.
+
+---
+
+## Documentation Practices
+
+### Use Context7 before implementing — `HARNESS`
+
+> - **Use Context7 (MCP)** before implementing with external frameworks, libraries, or APIs — always verify current best practices and API signatures rather than relying on training data that may be outdated
+
+Superseded by the Context7 MCP server's **own** instructions, which are injected whenever the server is connected: _"Use this server to fetch current documentation whenever the user asks about a library, framework, SDK, API, CLI tool, or cloud service… Use even when you think you know the answer — your training data may not reflect recent changes."_
+
+This is the cleanest redundancy in the file: the tool already advocates for itself.
+
+### Update documentation / document breaking changes — `TOOLED`
+
+> - Update project documentation when changing functionality
+> - Document breaking changes clearly
+
+Owned by `/drift-check` (pre-PR doc-drift check) and `/readme-refresh`. Watch this one — it is the most likely re-add candidate in this section, because doc drift is silent and the skills are opt-in.
+
+---
+
+## PRD-Driven Development
+
+### Templates and shared-docs bullets — `TOOLED`
+
+> - **Templates**: Starter templates for new projects live in `~/.claude/docs/prd-workflow/templates/` — PRD files and project CLAUDE.md.
+> - **Shared docs**: `~/.claude/docs/label-taxonomy.md` provides project-agnostic references for labeling conventions and branch naming.
+
+Both paths are reachable from the `~/.claude/docs/README.md` index, which the trimmed file still points at. `/bootstrap-prd` owns the template workflow and names its own paths.
+
+---
+
+## Git Workflow
+
+### Re-read your changes before committing — `TOOLED`
+
+> - **Before committing**: Re-read your changes for unnecessary complexity, redundant code, and unclear naming
+
+This is the entire job description of `/simplify`, which runs at exactly this moment in the pipeline.
+
+---
+
+## Code Quality
+
+The whole block below is the closest analogue in this file to what Anthropic deleted from the Claude Code system prompt for Opus 5 — behavioral correction for a model that needed it.
+
+### Testing — `GENERIC`
+
+> - **Testing**: Follow AAA pattern (Arrange, Act, Assert). Test behavior, not implementation — if a refactor breaks tests but not code, the tests were wrong. Test edges and errors, not just the happy path. Mock boundaries (slow, non-deterministic, or external services), not internal logic.
+
+The "mock boundaries, not internal logic" clause is the most opinionated part and the likeliest re-add.
+
+### Error handling — `GENERIC`
+
+> - **Error Handling**: Fail fast, provide context, use specific exceptions
+
+### Dependencies — `GENERIC`
+
+> - **Dependencies**: Pin versions, use lock files
+
+### Security — `GENERIC`
+
+> - **Security**: Never commit secrets, API keys, or sensitive data
+
+Also enforced by the harness itself, which refuses to commit detected secrets.
+
+### Comments — `GENERIC`
+
+> - **Comments**: No commented-out code — delete it. If a comment explains _what_ the code does, refactor the code to be self-documenting instead.
+
+Partially superseded by _"match its comment density, naming, and idiom."_ Worth watching: leftover commented-out code is a real model habit, and `/simplify` may or may not catch it.
+
+**Kept:** the Linting bullet (zero-warnings policy plus the justified-inline-ignore escape hatch) and the code review order, both of which are Joshua's standards rather than general practice.
+
+---
+
+## Browser & Responsive QA — `RELOCATED`
+
+**Not cut.** The full ~440-word body moved to [`responsive-qa.md`](responsive-qa.md); a 3-line trigger with the load-bearing warning stays in the global file.
+
+Rationale (decision D5 on #252): this is the one section that **must not** be blind-ablated. Its failure mode is silent — `resize_window` returns `Successfully resized window … to 375x812` while `window.innerWidth` stays at 2315, and the horizontal-overflow check then _passes trivially_ because a desktop-width layout has no overflow. Cutting it would produce **no stumble-log entry**, which defeats the method. Relocation preserves the trigger at roughly a tenth of the always-loaded cost.
+
+Phase 4 on #252 decides whether the doc becomes a skill with a trigger description, which would drop the global cost to zero.
+
+---
+
+## Markdown
+
+### Label code blocks with a language identifier — `TOOLED`
+
+> - Always label code blocks with a language identifier (e.g., `bash`, `ruby`, `yaml`, `json`, `text`) to avoid linting errors
+
+Enforced by markdownlint MD040 via the pre-commit hook. The hook fails the commit, which is a harder guarantee than a prompt line.
+
+**Kept:** the no-hard-wraps rule. Hard-wrapping markdown prose is a genuine model habit, MD013 is disabled in `markdown/.markdownlint-cli2.yaml`, so nothing mechanical catches it.

--- a/claude/.claude/docs/attic-2026-08.md
+++ b/claude/.claude/docs/attic-2026-08.md
@@ -3,7 +3,7 @@
 Quarantined text removed from `~/.claude/CLAUDE.md` in Phase 1 of the config-trim initiative. **Nothing here is deleted** — this file exists so that re-adding a line is a two-second copy-paste rather than a git-archaeology session.
 
 - **Tracking issue:** joshukraine/dotfiles#252
-- **Removed on:** 2026-08-01 (1,675 words → 977, a 42% cut). The original projection was ~650; the PRD conventions and the full commit protocol were kept intact, the latter pending the Q1 test.
+- **Removed on:** 2026-08-01 (1,675 words → 1,015, a 39% cut). The original projection was ~650; the PRD conventions were kept intact, and the commit protocol was rewritten rather than cut once the Q1 test came back (see below).
 - **Evidence for re-adding:** `stumble-log.md`, and nothing else. A line comes back only if it appears in that log **more than once** (decision D1/D3 on #252). Re-add at the narrowest scope that fixes it: skill > project `CLAUDE.md` > global.
 
 Each entry below records the verbatim text and **why** it was cut. The reason codes:
@@ -14,6 +14,7 @@ Each entry below records the verbatim text and **why** it was cut. The reason co
 | **GENERIC** | Standard practice a current model does unprompted; the class of instruction Anthropic deleted for Opus 5 |
 | **TOOLED** | Enforced mechanically (linter, pre-commit hook) or owned by a skill, so the prose is belt-and-braces |
 | **RELOCATED** | Not cut — moved to a just-in-time location, with a pointer left behind |
+| **FALSIFIED** | Tested empirically and found to be untrue of the current harness |
 
 ---
 
@@ -142,6 +143,29 @@ Partially superseded by _"match its comment density, naming, and idiom."_ Worth 
 Rationale (decision D5 on #252): this is the one section that **must not** be blind-ablated. Its failure mode is silent — `resize_window` returns `Successfully resized window … to 375x812` while `window.innerWidth` stays at 2315, and the horizontal-overflow check then _passes trivially_ because a desktop-width layout has no overflow. Cutting it would produce **no stumble-log entry**, which defeats the method. Relocation preserves the trigger at roughly a tenth of the always-loaded cost.
 
 Phase 4 on #252 decides whether the doc becomes a skill with a trigger description, which would drop the global cost to zero.
+
+---
+
+## Git Commit Protocol
+
+### The permission-system rationale — `FALSIFIED`
+
+> Claude Code's permission system flags command substitution — `$(...)` and backticks, **including backticks inside double quotes** — _before_ the allow-list or auto mode is consulted, so a commit command containing them prompts for approval even when `git commit` is allow-listed.
+
+**Tested 2026-08-01** (#252 Q1) on a throwaway branch with four `--allow-empty` commits, with `Bash(git commit:*)` allow-listed and `defaultMode: auto`:
+
+| Message form | Prompted? | What landed in the message |
+| --- | --- | --- |
+| `-m "plain text"` | no | correct (baseline) |
+| ``-m "a `code ref` inside"`` | **no** | `a  inside` — **the backticked phrase was silently deleted** |
+| `-m "a $(echo INJECTED) inside"` | **no** | `a INJECTED inside` — **substitution ran and was inlined** |
+| **single** quotes, same backticks and `$(...)` | no | **exactly correct** — both preserved literally |
+
+Zero prompts across all four. **The stated rationale is dead:** the permission system did not pre-flag substitution, and the allow-list was honored in every case.
+
+**But the section's conclusion survives for a better reason,** so it was rewritten rather than cut: the shell still performs the substitution, which silently corrupts the commit message and does not abort the commit. That is a _worse_ failure mode than a permission prompt — a prompt is visible and stops you; a mangled message just ships. The rewrite also adds a newly-verified light path (single quotes preserve both literally, for one-liners with no apostrophe).
+
+Worth noting as a method lesson: the empirical answer was neither "still needed" nor "collapses to one line" — it was **right conclusion, wrong reason.** Neither of the two outcomes predicted on #252 was correct, which is the argument for testing instead of reasoning about it.
 
 ---
 

--- a/claude/.claude/docs/responsive-qa.md
+++ b/claude/.claude/docs/responsive-qa.md
@@ -1,0 +1,40 @@
+# Browser & Responsive QA
+
+How to verify a layout at a mobile breakpoint so the result is actually trustworthy. Read this **before** checking any layout at a mobile width through a browser-automation MCP.
+
+Extracted from the global `CLAUDE.md` in Phase 1 of joshukraine/dotfiles#252. The global file keeps a short trigger pointing here; the body lives at this path because it is irrelevant in most sessions and load-bearing in a few.
+
+## The core rule
+
+**Verify mobile/responsive widths by emulating the CSS viewport, never by resizing the OS window.**
+
+When checking a layout at a mobile breakpoint (e.g. the common 375px), use the device-emulation tool — `emulate` in the chrome-devtools MCP, with a viewport like `375x812x3,mobile,touch` — not a window-resize tool (`resize_page`, `resize_window`).
+
+**A window-resize tool reports success without moving the CSS viewport.** Observed 2026-07-28 with Claude in Chrome's `resize_window` on euroteamoutreach.org: it returned `Successfully resized window ... to 375x812`, while `window.innerWidth` stayed at **2315** and the `sm:` breakpoint remained active.
+
+The failure is silent in the worst way — **the overflow check then _passes_**, because a desktop-width layout has no horizontal overflow. You get a green result that means nothing.
+
+> An earlier version of this note said Chrome clamps to a ~500px minimum. It may clamp on some setups; it may also ignore the resize entirely. Either way the viewport is not what you asked for, so **never infer the width from the tool's return value.**
+
+## Always confirm the viewport actually took
+
+A screenshot alone does not prove the width. After emulating, assert via the page-eval tool that:
+
+1. `window.innerWidth` equals the target width, **and**
+2. `document.documentElement.scrollWidth <= window.innerWidth` (the horizontal-overflow check)
+
+**`innerWidth` is the load-bearing half.** The `scrollWidth <= innerWidth` comparison passes trivially at the wrong width, so it is only evidence once the width itself is confirmed. Check them in that order and report both.
+
+## `emulate` missing? The chrome-devtools MCP is project-scoped, not global
+
+It comes from a checked-in `.mcp.json` at the repo root (`chrome-devtools-mcp`, run with `--isolated` so it never touches the real browser session).
+
+Claude in Chrome is a separate, complementary server: it drives the real logged-in session but has **no viewport emulation, no Lighthouse, and no performance traces**.
+
+If a repo lacks `.mcp.json`, copy it from `ofreport.com-hugo`, `comix_distro`, or `euroteamoutreach.org-hugo` and restart Claude Code. **Do not fall back to `resize_window`.** Full rationale: `comix_distro/docs/chrome-devtools-mcp.md`.
+
+## Fallback: a same-origin iframe is a real CSS viewport
+
+When emulation genuinely isn't available, an iframe at the target width gives the inner document a true viewport that media queries evaluate against. Assert `innerWidth` and `scrollWidth` **inside** the iframe.
+
+Caveat: this fails on any site sending `X-Frame-Options: DENY` — which the Netlify sites do. So it works against a local dev server but **not** against a deploy preview.

--- a/claude/.claude/docs/stumble-log.md
+++ b/claude/.claude/docs/stumble-log.md
@@ -1,0 +1,49 @@
+# Stumble Log
+
+Running record of places where Claude got something wrong that a removed instruction would have prevented. **This log is the only admissible evidence for re-adding anything to a `CLAUDE.md` file** (decision D1 on joshukraine/dotfiles#252).
+
+## Why this exists
+
+The ablation method only works if the observation half actually happens. Cutting instructions and then re-adding them from memory or intuition reproduces the original file — the whole point is to let reality decide. So: cut in one pass, work normally, write down every stumble, and re-add only what earns it.
+
+## How to use it
+
+**For Claude:** when you realize you did something Joshua had to correct — and a line that used to be in a `CLAUDE.md` would have prevented it — append a row before moving on. Do this unprompted; it is part of finishing the task. Do not re-add the instruction yourself.
+
+**For Joshua:** when you catch yourself giving a correction you feel like you've given before, add a row (or tell Claude to). The "again?" feeling is the signal.
+
+**Rules:**
+
+- One row per incident, not per category. Three separate wrong-branch-prefix incidents are three rows.
+- Record what _actually happened_, not the instruction you wish existed. The fix column is a hypothesis.
+- **Do not re-add during the observation window** (Phase 2, ~2 weeks from 2026-08-01). Log and keep going. Re-adds happen in one deliberate Phase 3 pass.
+- A line comes back only if it appears here **more than once**. Single incidents are noise.
+- Re-add at the narrowest scope that fixes it: skill > project `CLAUDE.md` > global.
+
+## Log
+
+| Date | Repo | What happened | Candidate fix | Scope |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+<!-- Example row, delete once real entries exist:
+| 2026-08-04 | comix_distro | Left three blocks of commented-out ERB in a view; Joshua flagged it in review | Re-add the "no commented-out code" line from attic-2026-08.md § Code Quality → Comments | project |
+-->
+
+## Watch list
+
+Cuts flagged during Phase 1 as the likeliest to come back, so a stumble here is expected rather than surprising. Listing them does **not** pre-authorize a re-add — they still need two logged incidents.
+
+| Candidate | Why it's at risk |
+| --- | --- |
+| Update docs when functionality changes | Doc drift is silent; `/drift-check` is opt-in and easy to skip |
+| No commented-out code | A real model habit; only partially covered by "match surrounding idiom" |
+| Mock boundaries, not internal logic | The most opinionated testing line in the removed block |
+| Keep changes small and isolated | Cheap to state, and large diffs are hard to review after the fact |
+
+## Non-candidates
+
+Never re-add these to the global file regardless of what the log says — they are structural decisions, not preferences:
+
+- Anything already near-verbatim in Claude Code's own system prompt (see the `HARNESS` entries in [`attic-2026-08.md`](attic-2026-08.md)). If a system-prompt-covered behavior regresses, that is a model or harness observation worth reporting, not a `CLAUDE.md` line.
+- Anything relevant to fewer than half of repositories. That belongs in a project `CLAUDE.md` or a skill — the global file loads in every session, including Ukrainian-translation and dotfiles sessions with no code in them.


### PR DESCRIPTION
Phase 1 of the config-trim initiative tracked in #252. **Does not close it** — #252 stays open through Phases 2–7.

Global `CLAUDE.md`: **1,675 → 977 words (42%)**. Nothing hard-deleted; every cut is quarantined with a reason.

## What to review

The diff on `claude/.claude/CLAUDE.md` is the decision. Everything else is scaffolding to make the decision reversible. Read the attic alongside it — it names the reason for every cut, so a veto is "put that one back" rather than a re-litigation.

## Cuts, by reason

| Reason | What went | Why |
| --- | --- | --- |
| **HARNESS** | "Finish the job" · "Bias toward action" (head clause) · "flag it honestly" · "prefer established patterns" · the Context7 bullet | Now near-verbatim in Claude Code's own system prompt, or — for Context7 — in the MCP server's own injected instructions. Paying tokens to tell the model something it is already told. |
| **GENERIC** | The whole Code Quality block: testing/AAA, error handling, dependencies, security, comments | The closest analogue in this file to what Anthropic deleted for Opus 5 — behavioral correction for a model that needed it. |
| **TOOLED** | Code-block language labels · "re-read before committing" · PRD template paths | Enforced by markdownlint MD040, owned by `/simplify`, and reachable from the docs index respectively. A failing pre-commit hook is a harder guarantee than a prompt line. |

## What was deliberately kept

- **Language (Ukrainian)** — verbatim. Unguessable and high-value.
- **PRD conventions** — the arbitrary vocabulary (`[—]` glyph, RFC keyword meanings, the `→ See 07-feature.md §3 "Heading"` cross-ref format) is not derivable. Compressed, not cut.
- **Git conventions** — Conventional Commits, no issue refs in commits, the multi-issue closing-keyword check, squash merges, the `git -C` permission note.
- **"Ask before" tail clause** — the generic head was cut, but the specific list (interfaces, data models, destructive operations) is your calibration.
- **Linting zero-warnings + review order** — your standards, not general practice.
- **No hard wraps** — a real model habit, and MD013 is disabled so nothing mechanical catches it.
- **Git Commit Protocol** — intact, flagged pending the Q1 harness test. It is a harness fact, not a model instruction; cutting it on a guess would be wrong.

## The one relocation, not a cut

**Browser & Responsive QA** (~440 words, 26% of the old file) → `docs/responsive-qa.md`, with a three-line trigger left in the global file.

This section must not be blind-ablated. Its failure mode is silent: `resize_window` returns `Successfully resized window … to 375x812` while `window.innerWidth` stays at 2315, and the horizontal-overflow check then *passes trivially* because a desktop-width layout has no overflow. Cutting it would produce **no stumble-log entry** — a green result that means nothing, and no signal that anything went wrong. That defeats the method, so the trigger stays. Always-loaded cost drops ~440w → ~40w.

Phase 4 on #252 decides whether it becomes a skill, which would take the global cost to zero.

## Guardrails added

| File | Role |
| --- | --- |
| `docs/attic-2026-08.md` | Quarantine. Every removed line verbatim, with its reason code and what supersedes it. |
| `docs/stumble-log.md` | The **only** admissible evidence for a re-add. Includes a watch list of the four likeliest returns and a non-candidates list that can never come back to the global file. |

## Verification

- `markdownlint-cli2` with `markdown/.markdownlint-cli2.yaml`: 0 issues in 7 files
- `./scripts/lint-shell`: 45 scripts, all passed
- `./scripts/run-tests`: 106 tests, all passed
- Confirmed `~/.claude/CLAUDE.md` is still the stow symlink into this repo, so the trim is live

## Second commit — #252 Q1 and Q2 resolved

Both open questions came back answered, so this PR now carries their fallout. Final word count **1,015 (39% cut)**, up from 977 — the commit protocol was rewritten rather than cut, and the Q2 bullet got longer in exchange for deleting language from two project repos.

### Q1 — right conclusion, wrong reason

Tested instead of reasoned about: four `--allow-empty` commits on a throwaway branch, `Bash(git commit:*)` allow-listed, `defaultMode: auto`.

| Message form | Prompted? | What landed |
| --- | --- | --- |
| double quotes, plain text | no | correct (baseline) |
| double quotes, backticked phrase | **no** | phrase **silently deleted** |
| double quotes, `$(echo INJECTED)` | **no** | substitution **ran and was inlined** |
| **single** quotes, same content | no | **exactly correct**, both literal |

**Zero prompts across all four** — the stated rationale is dead. But the conclusion survives for a *worse* reason: the shell performs the substitution and the commit still succeeds, so a mangled message ships silently where a prompt would have been visible and stopped you. Section rewritten, rationale replaced, and a newly verified light path documented (single quotes, for a one-liner with no apostrophe).

Neither outcome this PR originally predicted was correct. Logged in the attic under a new **FALSIFIED** reason code, as the standing argument for testing over guessing.

### Q2 — retire tutorial mode, keep the understanding

"Understanding transfer is critical" → "**Understanding transfer, not tutoring**", now naming both failure modes instead of one. Rules out concept tutorials for tech already shipping in production, narration of what the code plainly says, and pausing to offer a choice when one option is clearly right — while explicitly warning against over-correcting into terseness. Discriminator: **explain the decision, not the syntax.**

Grep confirms no tutorial-mode language anywhere else in this repo, **including the PRD starter template**, so nothing propagates to new projects. The two project repos that do carry it (`ofreport.com-hugo`, `euroteamoutreach.org`) are handled separately — Phase 7 on #252.

## Next, after merge

Phase 2 is an **observation window** — roughly two weeks of normal work with no re-adds. The rule that makes it work: log stumbles, don't fix them in the moment. Re-adds happen in one deliberate Phase 3 pass, and only for entries logged more than once.

